### PR TITLE
Rolled back igv.js version to `2.7.4`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "classnames": "^2.2.6",
     "d3": "^3.5.17",
     "d3-scale": "^3.2.3",
-    "igv": "^2.7.5",
+    "igv": "2.7.4",
     "material-ui-popup-state": "^1.7.1",
     "moment": "^2.29.1",
     "primeflex": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8595,23 +8595,27 @@ ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-"igv-ui@github:igvteam/igv-ui#a409ba5c":
-  version "1.1.1"
-  resolved "https://codeload.github.com/igvteam/igv-ui/tar.gz/a409ba5c4ea6f20dc87b6c8d43bfd889cfa191c6"
+"igv-ui@github:igvteam/igv-ui#23d667e6":
+  version "1.0.3"
+  resolved "https://codeload.github.com/igvteam/igv-ui/tar.gz/23d667e64b1207d762b583d4d0826cb0148b4d49"
   dependencies:
-    igv-utils "github:igvteam/igv-utils#6c830b25"
+    igv-utils "github:igvteam/igv-utils#36c425bb"
 
-"igv-utils@github:igvteam/igv-utils#6c830b25":
-  version "1.2.2"
-  resolved "https://codeload.github.com/igvteam/igv-utils/tar.gz/6c830b25c81513ace1403f854df5a89491727a3d"
+"igv-utils@github:igvteam/igv-utils#0e7dbafb":
+  version "1.1.0"
+  resolved "https://codeload.github.com/igvteam/igv-utils/tar.gz/0e7dbafb3d0ce556596c2d8e6e78c9b15dc208b4"
 
-igv@^2.7.5:
-  version "2.7.5"
-  resolved "https://registry.yarnpkg.com/igv/-/igv-2.7.5.tgz#87e0108c42b21cc3a70e58cc3a3d715d7c0da08c"
-  integrity sha512-zswjlhQ0lR2GKRVaMjEd/Tou5CXNzvJfUoPImE7vWKCwlJPIQSKx9Ol3p33wZ7LT3HoLwL3NdpsyeP0Q1oldoQ==
+"igv-utils@github:igvteam/igv-utils#36c425bb":
+  version "1.1.0"
+  resolved "https://codeload.github.com/igvteam/igv-utils/tar.gz/36c425bb3e02d5a0e821e39dd1cf510c550f29e5"
+
+igv@2.7.4:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/igv/-/igv-2.7.4.tgz#42e5b76f4accf2113999e343dc78816d15f6b069"
+  integrity sha512-ITTV7GTDPpTmxDpBfDACwarIHr6sDuXv9yTYaMgosdq3p2jEK7GzjxO5w2stUm4vxA+gSI/hoF6DFNzll1cClw==
   dependencies:
-    igv-ui "github:igvteam/igv-ui#a409ba5c"
-    igv-utils "github:igvteam/igv-utils#6c830b25"
+    igv-ui "github:igvteam/igv-ui#23d667e6"
+    igv-utils "github:igvteam/igv-utils#0e7dbafb"
 
 immer@8.0.1:
   version "8.0.1"


### PR DESCRIPTION
* Seem to something wrong with `2.7.5` module export. Build failed with:
  `Cannot find module: 'igv'. Make sure this package is installed.`
