### PR TITLE
Excluded pre-commit from yarn install prepare hook

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,9 +3,9 @@ phases:
   install:
     runtime-versions:
       nodejs: 14
-      python: 3.9
+#      python: 3.9
     commands:
-      - pip install detect-secrets pre-commit
+#      - pip install detect-secrets pre-commit
       - yarn install
   build:
     commands:

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "test": "react-scripts test --env=jsdom --watchAll=false",
     "eject": "react-scripts eject",
     "lint": "eslint src",
-    "prepare": "pre-commit install",
     "precommit": "pre-commit run --all-files"
   },
   "eslintConfig": {


### PR DESCRIPTION
* On CodeBuild VM, src is none git checkout
* Might as well too late at this point if secrets detect
  or audit failure when building client artifact. These
  should be prevented before even PR get merges to main or
  dev branches.
