### PR TITLE
Add file preview for PresignedUrl

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^17.0.2",
     "react-ga": "^3.3.0",
+    "react-json-pretty": "^2.2.0",
     "react-moment": "^1.1.2",
     "react-redux": "^7.2.8",
     "react-router-dom": "^5.3.0",

--- a/src/components/PreviewActionButton.tsx
+++ b/src/components/PreviewActionButton.tsx
@@ -33,6 +33,8 @@ import { makeStyles } from '@material-ui/core/styles';
 import JSONPretty from 'react-json-pretty';
 
 const IMAGE_FILETYPE_LIST: string[] = ['png', 'jpg', 'jpeg'];
+const DELIMITER_SERPERATED_VALUE_FILETYPE_LIST: string[] = ['csv', 'tsv'];
+const PLAIN_FILETYPE_LIST: string[] = ['txt', 'md5sum'];
 /**
  * Preview Action Button
  */
@@ -70,7 +72,14 @@ export default function PreviewActionButton({ data }: Props) {
 
 // Helper Function
 function isDataTypeSupported(name: string) {
-  const dataTypeSupported = [...IMAGE_FILETYPE_LIST, 'html', 'tsv', 'csv', 'json', 'txt', 'yaml'];
+  const dataTypeSupported = [
+    ...IMAGE_FILETYPE_LIST,
+    ...DELIMITER_SERPERATED_VALUE_FILETYPE_LIST,
+    ...PLAIN_FILETYPE_LIST,
+    'html',
+    'json',
+    'yaml',
+  ];
 
   for (const dataType of dataTypeSupported) {
     if (name.endsWith(dataType)) {
@@ -95,7 +104,8 @@ function DialogData({ data }: Props) {
     presignedUrlContent: '',
   });
 
-  const fileType = data.name.split('.').pop();
+  // const fileType = data.name.split('.').pop();
+  let fileType = 'json';
 
   useEffect(() => {
     let componentUnmount = false;
@@ -126,7 +136,14 @@ function DialogData({ data }: Props) {
     <>
       {/* Dialog that opens the preview */}
       <DialogTitle>{data.name}</DialogTitle>
-      <DialogContent style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+      <DialogContent
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          backgroundColor: '#525659',
+          overflow: 'hidden',
+        }}>
         {presignedUrlData.isLoading ? (
           <CircularProgress />
         ) : IMAGE_FILETYPE_LIST.includes(fileType) ? (
@@ -148,7 +165,7 @@ function DialogData({ data }: Props) {
         ) : fileType === 'yaml' ? (
           <YAMLViewer fileContent={presignedUrlData.presignedUrlContent} />
         ) : (
-          <>{`Some Component`}</>
+          <PlainTextViewer fileContent={presignedUrlData.presignedUrlContent} />
         )}
       </DialogContent>
     </>
@@ -267,12 +284,12 @@ function JSONViewer({ fileContent }: JSONViewerProps) {
   const classes = useStyles();
 
   const cssTheme = {
-    main: 'line-height:1.3;color:#8dc4e2;background:#272822;overflow:auto;',
-    error: 'line-height:1.3;color:#8dc4e2;background:#272822;overflow:auto;',
-    key: 'color:#8dc4e2;',
-    string: 'color:#bb846e;',
-    value: 'color:#b2caa5;',
-    boolean: 'color:#bb846e;',
+    main: 'line-height:1.3;color:#a21515;background:#ffffff;overflow:auto;',
+    error: 'line-height:1.3;color:#a21515;background:#ffffff;overflow:auto;',
+    key: 'color:#a21515;',
+    string: 'color:#0551a5;',
+    value: 'color:#0b8658;',
+    boolean: 'color:#0551a5;',
   };
 
   // Sanitize if JSON is
@@ -293,6 +310,7 @@ function JSONViewer({ fileContent }: JSONViewerProps) {
         data={JSONParse}
         theme={cssTheme}
         style={{
+          borderRadius: '5px',
           overflow: 'auto',
         }}
       />
@@ -302,5 +320,38 @@ function JSONViewer({ fileContent }: JSONViewerProps) {
 
 type YAMLViewerProps = { fileContent: string };
 function YAMLViewer({ fileContent }: YAMLViewerProps) {
-  return <pre style={{ border:"1px solid black", backgroundColor: 'white', padding:"1rem" }}>{fileContent}</pre>;
+  return (
+    <div style={{ maxHeight: '80vh', maxWidth: '100%', overflow: 'auto', margin: '1rem' }}>
+      <pre
+        style={{
+          display: 'inline-block',
+          borderRadius: '5px',
+          border: '1px solid black',
+          backgroundColor: 'white',
+          padding: '1rem',
+          margin: 0,
+        }}>
+        {fileContent}
+      </pre>
+    </div>
+  );
+}
+
+type PlainTextViewerProps = { fileContent: string };
+function PlainTextViewer({ fileContent }: PlainTextViewerProps) {
+  return (
+    <div style={{ maxHeight: '80vh', maxWidth: '100%', overflow: 'auto', margin: '1rem' }}>
+      <pre
+        style={{
+          display: 'inline-block',
+          borderRadius: '5px',
+          border: '1px solid black',
+          backgroundColor: 'white',
+          padding: '1rem',
+          margin: 0,
+        }}>
+        {fileContent}
+      </pre>
+    </div>
+  );
 }

--- a/src/components/PreviewActionButton.tsx
+++ b/src/components/PreviewActionButton.tsx
@@ -1,0 +1,129 @@
+/* eslint-disable */
+import React, { useState, useEffect } from 'react';
+
+// AWS Amplify
+import { API } from 'aws-amplify';
+
+// Material- UI
+import WarningIcon from '@material-ui/icons/Warning';
+import VisibilityIcon from '@material-ui/icons/Visibility';
+import IconButton from '@material-ui/core/IconButton';
+import Dialog, { DialogProps } from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { Typography } from '@material-ui/core';
+
+const IMAGE_FILETYPE_LIST: string[] = ['png', 'jpg', 'jpeg'];
+/**
+ * Preview Action Button
+ */
+type Props = { data: any };
+
+export default function PreviewActionButton({ data }: Props) {
+  const isPreviewSupported = isDataTypeSupported(data.name);
+
+  if (!isPreviewSupported) {
+    return (
+      <IconButton disabled={true}>
+        <WarningIcon />
+      </IconButton>
+    );
+  } else {
+    return <PreviewButton data={data} />;
+  }
+}
+
+// Helper Function
+function isDataTypeSupported(name: string) {
+  const dataTypeSupported = [...IMAGE_FILETYPE_LIST, 'tsv', 'csv', 'json', 'txt', 'yaml'];
+
+  for (const dataType of dataTypeSupported) {
+    if (name.endsWith(dataType)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Handle Preview Button when Open
+ */
+
+function PreviewButton({ data }: Props) {
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isPreviewOpen, setIsPreviewOpen] = useState<boolean>(false);
+  const [presignedUrl, setPresignedUrl] = useState<string>('');
+
+  const fileType = data.name.split('.').pop();
+
+  useEffect(() => {
+    let componentUnmount = false;
+
+    const fetchPresignedUrl = async () => {
+      setIsLoading(true);
+
+      const presignedUrlRequest = await getPreSignedUrl(data.id);
+
+      if (componentUnmount) return;
+
+      setPresignedUrl(presignedUrlRequest);
+      setIsLoading(false);
+    };
+    fetchPresignedUrl();
+
+    return () => {
+      componentUnmount = true;
+    };
+  }, [data.id]);
+
+  return (
+    <>
+      {/* Button to open preview */}
+      <IconButton onClick={() => setIsPreviewOpen(true)}>
+        <VisibilityIcon />
+      </IconButton>
+
+      {/* Dialog that opens the preview */}
+      <Dialog
+        maxWidth='lg'
+        fullWidth={true}
+        open={isPreviewOpen}
+        onClose={() => setIsPreviewOpen(false)}>
+        <DialogTitle>{data.name}</DialogTitle>
+
+        <DialogContent style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+          {isLoading ? (
+            <CircularProgress />
+          ) : IMAGE_FILETYPE_LIST.includes(fileType) ? (
+            <ImageViewer presignedUrl={presignedUrl} />
+          ) : fileType === 'txt' ? (
+            <TxtViewer presignedUrl={presignedUrl} />
+          ) : (
+            <>{`Some Component`}</>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+// Helper function
+async function getPreSignedUrl(id: string) {
+  return await API.get('files', `/gds/${id}/presign`, {});
+}
+
+/**
+ * Component to view preSignedURL data
+ */
+type ImageViewerProps = { presignedUrl: string };
+function ImageViewer({ presignedUrl }: ImageViewerProps) {
+  return <img style={{ maxHeight: '100%', maxWidth: '100%' }} src={presignedUrl} />;
+}
+
+type TxtViewerProps = { presignedUrl: string };
+function TxtViewer({ presignedUrl }: TxtViewerProps) {
+  return <Typography>{presignedUrl}</Typography>;
+}

--- a/src/components/PreviewActionButton.tsx
+++ b/src/components/PreviewActionButton.tsx
@@ -95,8 +95,7 @@ function DialogData({ data }: Props) {
     presignedUrlContent: '',
   });
 
-  // const fileType = data.name.split('.').pop();
-  let fileType = 'json';
+  const fileType = data.name.split('.').pop();
 
   useEffect(() => {
     let componentUnmount = false;
@@ -146,6 +145,8 @@ function DialogData({ data }: Props) {
           />
         ) : fileType === 'json' ? (
           <JSONViewer fileContent={presignedUrlData.presignedUrlContent} />
+        ) : fileType === 'yaml' ? (
+          <YAMLViewer fileContent={presignedUrlData.presignedUrlContent} />
         ) : (
           <>{`Some Component`}</>
         )}
@@ -297,4 +298,9 @@ function JSONViewer({ fileContent }: JSONViewerProps) {
       />
     </Paper>
   );
+}
+
+type YAMLViewerProps = { fileContent: string };
+function YAMLViewer({ fileContent }: YAMLViewerProps) {
+  return <pre style={{ border:"1px solid black", backgroundColor: 'white', padding:"1rem" }}>{fileContent}</pre>;
 }

--- a/src/components/PreviewActionButton.tsx
+++ b/src/components/PreviewActionButton.tsx
@@ -5,6 +5,7 @@ import React, { useState, useEffect } from 'react';
 import { API } from 'aws-amplify';
 
 // Material- UI
+import AllOutIcon from '@material-ui/icons/AllOut';
 import WarningIcon from '@material-ui/icons/Warning';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import IconButton from '@material-ui/core/IconButton';
@@ -20,7 +21,6 @@ import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableContainer from '@material-ui/core/TableContainer';
 import TableHead from '@material-ui/core/TableHead';
-import TablePagination from '@material-ui/core/TablePagination';
 import TableRow from '@material-ui/core/TableRow';
 import Checkbox from '@material-ui/core/Checkbox';
 import FormGroup from '@material-ui/core/FormGroup';
@@ -40,16 +40,52 @@ const PLAIN_FILETYPE_LIST: string[] = ['txt', 'md5sum'];
  */
 type Props = { data: any };
 
+const useStylesButtonIcon = makeStyles({
+  typeWarning: {
+    position: 'relative',
+    '& p': {
+      display: 'none',
+      width: '100%',
+    },
+    '&:hover': {
+      '& p': {
+        backgroundColor: 'white',
+        border: '1px solid black',
+        position: 'absolute',
+        display: 'inline',
+        width: 'max-content',
+        top: '-2.2rem',
+        left: '-100%',
+        padding: '3px',
+      },
+    },
+  },
+});
+
 export default function PreviewActionButton({ data }: Props) {
-  const isPreviewSupported = isDataTypeSupported(data.name);
+  const iconClasses = useStylesButtonIcon();
+  const isDataTypeSupported = checkIsDataTypeSupoorted(data.name);
+  const isFileSizeSupported = checkIsFileSizeSupported(data.size_in_bytes);
 
   const [isPreviewOpen, setIsPreviewOpen] = useState<boolean>(false);
 
-  if (!isPreviewSupported) {
+  if (!isDataTypeSupported) {
     return (
-      <IconButton disabled={true}>
-        <WarningIcon />
-      </IconButton>
+      <div className={iconClasses.typeWarning}>
+        <IconButton disabled={true}>
+          <WarningIcon />
+        </IconButton>
+        <p>Unsupported FileType</p>
+      </div>
+    );
+  } else if (!isFileSizeSupported) {
+    return (
+      <div className={iconClasses.typeWarning}>
+        <IconButton disabled={true}>
+          <AllOutIcon />
+        </IconButton>
+        <p>FileSize exceed 15MB</p>
+      </div>
     );
   } else {
     return (
@@ -71,7 +107,7 @@ export default function PreviewActionButton({ data }: Props) {
 }
 
 // Helper Function
-function isDataTypeSupported(name: string) {
+function checkIsDataTypeSupoorted(name: string): boolean {
   const dataTypeSupported = [
     ...IMAGE_FILETYPE_LIST,
     ...DELIMITER_SERPERATED_VALUE_FILETYPE_LIST,
@@ -86,6 +122,11 @@ function isDataTypeSupported(name: string) {
       return true;
     }
   }
+  return false;
+}
+function checkIsFileSizeSupported(size_in_bytes: number): boolean {
+  // Only support file less than 15MB
+  if (size_in_bytes < 15000000) return true;
   return false;
 }
 
@@ -270,7 +311,7 @@ function DelimiterSeperatedValuesViewer(props: DelimiterSeperatedValuesViewerPro
   );
 }
 
-const useStyles = makeStyles({
+const useStylesJSONViewers = makeStyles({
   root: {
     '& pre': {
       margin: 0,
@@ -281,7 +322,7 @@ const useStyles = makeStyles({
 type JSONViewerProps = { fileContent: string };
 function JSONViewer({ fileContent }: JSONViewerProps) {
   const JSONParse = JSON.parse(fileContent);
-  const classes = useStyles();
+  const classes = useStylesJSONViewers();
 
   const cssTheme = {
     main: 'line-height:1.3;color:#a21515;background:#ffffff;overflow:auto;',

--- a/src/components/PreviewActionButton.tsx
+++ b/src/components/PreviewActionButton.tsx
@@ -27,6 +27,10 @@ import FormGroup from '@material-ui/core/FormGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormLabel from '@material-ui/core/FormLabel';
+import { makeStyles } from '@material-ui/core/styles';
+
+// Other Dependencies
+import JSONPretty from 'react-json-pretty';
 
 const IMAGE_FILETYPE_LIST: string[] = ['png', 'jpg', 'jpeg'];
 /**
@@ -91,7 +95,8 @@ function DialogData({ data }: Props) {
     presignedUrlContent: '',
   });
 
-  const fileType = data.name.split('.').pop();
+  // const fileType = data.name.split('.').pop();
+  let fileType = 'json';
 
   useEffect(() => {
     let componentUnmount = false;
@@ -139,6 +144,8 @@ function DialogData({ data }: Props) {
             fileContent={presignedUrlData.presignedUrlContent}
             delimiter='\t'
           />
+        ) : fileType === 'json' ? (
+          <JSONViewer fileContent={presignedUrlData.presignedUrlContent} />
         ) : (
           <>{`Some Component`}</>
         )}
@@ -149,8 +156,6 @@ function DialogData({ data }: Props) {
 
 // Helper function
 async function getPreSignedUrl(id: string) {
-  return 'https://umccr-temp-dev.s3.ap-southeast-2.amazonaws.com/william/test-head.csv?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIA4IXYHPYNGAMPUGH3%2F20220519%2Fap-southeast-2%2Fs3%2Faws4_request&X-Amz-Date=20220519T010754Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEAgaDmFwLXNvdXRoZWFzdC0yIkgwRgIhAOYmByZSzrHjwPEBA1RBk8whXCcmfm05Me8AmijUlZ%2B1AiEAkzTbUCoapcP3tbFaY3yqnMiEL4DiGUNNFBoVu8aKYvsqoQMI4f%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARADGgw4NDM0MDc5MTY1NzAiDFtMI%2F7IevQQnLESNSr1AnorHEMrHV9NIr4E%2FsX82gOZT9SS%2BZfvcXVrAavvNXpZ8Svr0c7krNUmmqcGoePOx%2FRVq0ixVAs2ipcPOpj01KAaoyHk0HfleFR%2Bjd1kv8gsIHKni7wK%2FL7lpsJa32JXCrTqsP%2FSGCQbRwOgt3vaV2w4nqocYDLgJkRRQxGjV1s3LANgEO0Kg51qXntua9GjTw3fTH5DV%2Fq0sCYzdsQOvNdJaKufP8Q2yYkwjE%2B%2BSYc38wIIXpQXhIa2xnQUwgVzl%2BvGA3Xe5mwTG6nqMg0aqrMZsFVyV5v%2Fy066GSpphKwm61S8yBusLbO1hkWyba99GaYjLt7bx66GVD1qGYBR59Z6D5H5K3iaOt1qLgaTy8D1JOPJMKBr%2B2EVbED0msx7KlEadIM5%2BvqRkl7wRAnCmh14upxGoctRzhHf0bi%2Beet7yH9Aq6%2FAWcqMulYHfzs2dPVuE292BKG6fxhSdCXPBIOfY13bJeZ6Yw%2FrlLIgdQTFDX%2B4kLoww4uWlAY6pQHOBU1PaXC7w%2Bq5%2BYn2D0rbZG7gX83i4q3oyv9lx3Fyrd2cwARgZHUOnJrjP%2FjFOAiffm0quBH4duHuNzRvCDJlgDfkzqaWSfOMn2mKE5Er0m2UCtzrzK30af%2B3Du01INuSAzhaLZ%2F9eoxPKBIcNObtEM5VkcLueBNw0b%2FJgaagVNZARovovI2Ts6sad3H%2FJI%2B85y0WOb14bCrTr2IxO0SFlMxTVFc%3D&X-Amz-Signature=46c035afff7a26eacd5780ec977037bd40da2fefad5d4c8150170a938b7418c6';
-  return 'https://umccr-temp-dev.s3.ap-southeast-2.amazonaws.com/william/test-head.tsv?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIA4IXYHPYNGAMPUGH3%2F20220519%2Fap-southeast-2%2Fs3%2Faws4_request&X-Amz-Date=20220519T005208Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEAgaDmFwLXNvdXRoZWFzdC0yIkgwRgIhAOYmByZSzrHjwPEBA1RBk8whXCcmfm05Me8AmijUlZ%2B1AiEAkzTbUCoapcP3tbFaY3yqnMiEL4DiGUNNFBoVu8aKYvsqoQMI4f%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARADGgw4NDM0MDc5MTY1NzAiDFtMI%2F7IevQQnLESNSr1AnorHEMrHV9NIr4E%2FsX82gOZT9SS%2BZfvcXVrAavvNXpZ8Svr0c7krNUmmqcGoePOx%2FRVq0ixVAs2ipcPOpj01KAaoyHk0HfleFR%2Bjd1kv8gsIHKni7wK%2FL7lpsJa32JXCrTqsP%2FSGCQbRwOgt3vaV2w4nqocYDLgJkRRQxGjV1s3LANgEO0Kg51qXntua9GjTw3fTH5DV%2Fq0sCYzdsQOvNdJaKufP8Q2yYkwjE%2B%2BSYc38wIIXpQXhIa2xnQUwgVzl%2BvGA3Xe5mwTG6nqMg0aqrMZsFVyV5v%2Fy066GSpphKwm61S8yBusLbO1hkWyba99GaYjLt7bx66GVD1qGYBR59Z6D5H5K3iaOt1qLgaTy8D1JOPJMKBr%2B2EVbED0msx7KlEadIM5%2BvqRkl7wRAnCmh14upxGoctRzhHf0bi%2Beet7yH9Aq6%2FAWcqMulYHfzs2dPVuE292BKG6fxhSdCXPBIOfY13bJeZ6Yw%2FrlLIgdQTFDX%2B4kLoww4uWlAY6pQHOBU1PaXC7w%2Bq5%2BYn2D0rbZG7gX83i4q3oyv9lx3Fyrd2cwARgZHUOnJrjP%2FjFOAiffm0quBH4duHuNzRvCDJlgDfkzqaWSfOMn2mKE5Er0m2UCtzrzK30af%2B3Du01INuSAzhaLZ%2F9eoxPKBIcNObtEM5VkcLueBNw0b%2FJgaagVNZARovovI2Ts6sad3H%2FJI%2B85y0WOb14bCrTr2IxO0SFlMxTVFc%3D&X-Amz-Signature=fbc6f181b36f3d44b2d1e23528ee01cf3389f8b3f777fe6d6e95833f6ffe7fa2';
   const apiResponse = await API.get('files', `/gds/${id}/presign`, {});
 
   if (Object.keys(apiResponse).includes('error')) {
@@ -244,5 +249,52 @@ function DelimiterSeperatedValuesViewer(props: DelimiterSeperatedValuesViewerPro
         </TableContainer>
       </Paper>
     </div>
+  );
+}
+
+const useStyles = makeStyles({
+  root: {
+    '& pre': {
+      margin: 0,
+    },
+  },
+});
+
+type JSONViewerProps = { fileContent: string };
+function JSONViewer({ fileContent }: JSONViewerProps) {
+  const JSONParse = JSON.parse(fileContent);
+  const classes = useStyles();
+
+  const cssTheme = {
+    main: 'line-height:1.3;color:#8dc4e2;background:#272822;overflow:auto;',
+    error: 'line-height:1.3;color:#8dc4e2;background:#272822;overflow:auto;',
+    key: 'color:#8dc4e2;',
+    string: 'color:#bb846e;',
+    value: 'color:#b2caa5;',
+    boolean: 'color:#bb846e;',
+  };
+
+  // Sanitize if JSON is
+  let JSONString: string = '';
+  try {
+    const JSONParse = JSON.parse(fileContent);
+    JSONString = JSON.stringify(JSONParse, null, 2);
+  } catch (err) {
+    JSONString = fileContent;
+  }
+  return (
+    <Paper
+      elevation={3}
+      className={classes.root}
+      style={{ maxWidth: '100%', maxHeight: '80vh', display: 'flex' }}>
+      <JSONPretty
+        id='json-pretty'
+        data={JSONParse}
+        theme={cssTheme}
+        style={{
+          overflow: 'auto',
+        }}
+      />
+    </Paper>
   );
 }

--- a/src/components/PreviewActionButton.tsx
+++ b/src/components/PreviewActionButton.tsx
@@ -5,6 +5,7 @@ import React, { useState, useEffect } from 'react';
 import { API } from 'aws-amplify';
 
 // Material- UI
+import CloseIcon from '@material-ui/icons/Close';
 import AllOutIcon from '@material-ui/icons/AllOut';
 import WarningIcon from '@material-ui/icons/Warning';
 import VisibilityIcon from '@material-ui/icons/Visibility';
@@ -100,6 +101,11 @@ export default function PreviewActionButton({ data }: Props) {
           open={isPreviewOpen}
           onClose={() => setIsPreviewOpen(false)}>
           <DialogData data={data} />
+          <IconButton
+            style={{ position: 'absolute', right: '0', top: '5px' }}
+            onClick={() => setIsPreviewOpen(false)}>
+            <CloseIcon />
+          </IconButton>
         </Dialog>
       </>
     );

--- a/src/components/PreviewActionButton.tsx
+++ b/src/components/PreviewActionButton.tsx
@@ -91,8 +91,7 @@ function DialogData({ data }: Props) {
     presignedUrlContent: '',
   });
 
-  // const fileType = data.name.split('.').pop();
-  let fileType = 'csv';
+  const fileType = data.name.split('.').pop();
 
   useEffect(() => {
     let componentUnmount = false;
@@ -132,6 +131,8 @@ function DialogData({ data }: Props) {
           <HTMLViewers fileContent={presignedUrlData.presignedUrlContent} />
         ) : fileType === 'csv' ? (
           <CSVViewers fileContent={presignedUrlData.presignedUrlContent} />
+        ) : fileType === 'tsv' ? (
+          <TSVViewers fileContent={presignedUrlData.presignedUrlContent} />
         ) : (
           <>{`Some Component`}</>
         )}
@@ -221,6 +222,66 @@ function CSVViewers({ fileContent }: CSVViewersProps) {
                 return (
                   <TableRow hover role='checkbox' tabIndex={-1} key={index}>
                     {row.split(',').map((value: string, index: number) => {
+                      return <TableCell key={index}>{value}</TableCell>;
+                    })}
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Paper>
+    </div>
+  );
+}
+
+type TSVViewersProps = { fileContent: string };
+function TSVViewers({ fileContent }: TSVViewersProps) {
+  const [isFirstRowHeader, setIsFirstRowHeader] = useState<boolean>(true);
+
+  // Sanitize and split string
+  const sanitizeContent: string = fileContent.replaceAll('\r\n', '\n');
+  const allRows: string[] = sanitizeContent.split('\n').filter((element) => element);
+
+  const dataRows = allRows.slice(isFirstRowHeader ? 1 : 0);
+  const headerRow = isFirstRowHeader ? allRows[0] : null;
+
+  return (
+    <div style={{ width: '100%' }}>
+      <FormControlLabel
+        value='end'
+        control={
+          <Checkbox
+            color='primary'
+            size='small'
+            checked={isFirstRowHeader}
+            onChange={() => setIsFirstRowHeader((prev) => !prev)}
+          />
+        }
+        label='Header row'
+        labelPlacement='end'
+        style={{ marginBottom: '0.5rem' }}
+      />
+      <Paper elevation={3} style={{ width: '100%' }}>
+        <TableContainer style={{ maxHeight: '75vh' }}>
+          <Table stickyHeader aria-label='sticky table'>
+            <TableHead>
+              {headerRow ? (
+                <TableRow>
+                  {headerRow.split('\t').map((column: string) => (
+                    <TableCell key={column}>{column}</TableCell>
+                  ))}
+                </TableRow>
+              ) : (
+                <></>
+              )}
+            </TableHead>
+
+            <TableBody>
+              {dataRows.map((row: string, index: number) => {
+                return (
+                  <TableRow hover role='checkbox' tabIndex={-1} key={index}>
+                    {row.split('\t').map((value: string, index: number) => {
                       return <TableCell key={index}>{value}</TableCell>;
                     })}
                   </TableRow>

--- a/src/components/PreviewActionButton.tsx
+++ b/src/components/PreviewActionButton.tsx
@@ -128,11 +128,17 @@ function DialogData({ data }: Props) {
         ) : IMAGE_FILETYPE_LIST.includes(fileType) ? (
           <ImageViewer presignedUrl={presignedUrlData.presignedUrlString} />
         ) : fileType === 'html' ? (
-          <HTMLViewers fileContent={presignedUrlData.presignedUrlContent} />
+          <HTMLViewer fileContent={presignedUrlData.presignedUrlContent} />
         ) : fileType === 'csv' ? (
-          <CSVViewers fileContent={presignedUrlData.presignedUrlContent} />
+          <DelimiterSeperatedValuesViewer
+            fileContent={presignedUrlData.presignedUrlContent}
+            delimiter=','
+          />
         ) : fileType === 'tsv' ? (
-          <TSVViewers fileContent={presignedUrlData.presignedUrlContent} />
+          <DelimiterSeperatedValuesViewer
+            fileContent={presignedUrlData.presignedUrlContent}
+            delimiter='\t'
+          />
         ) : (
           <>{`Some Component`}</>
         )}
@@ -143,6 +149,8 @@ function DialogData({ data }: Props) {
 
 // Helper function
 async function getPreSignedUrl(id: string) {
+  return 'https://umccr-temp-dev.s3.ap-southeast-2.amazonaws.com/william/test-head.csv?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIA4IXYHPYNGAMPUGH3%2F20220519%2Fap-southeast-2%2Fs3%2Faws4_request&X-Amz-Date=20220519T010754Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEAgaDmFwLXNvdXRoZWFzdC0yIkgwRgIhAOYmByZSzrHjwPEBA1RBk8whXCcmfm05Me8AmijUlZ%2B1AiEAkzTbUCoapcP3tbFaY3yqnMiEL4DiGUNNFBoVu8aKYvsqoQMI4f%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARADGgw4NDM0MDc5MTY1NzAiDFtMI%2F7IevQQnLESNSr1AnorHEMrHV9NIr4E%2FsX82gOZT9SS%2BZfvcXVrAavvNXpZ8Svr0c7krNUmmqcGoePOx%2FRVq0ixVAs2ipcPOpj01KAaoyHk0HfleFR%2Bjd1kv8gsIHKni7wK%2FL7lpsJa32JXCrTqsP%2FSGCQbRwOgt3vaV2w4nqocYDLgJkRRQxGjV1s3LANgEO0Kg51qXntua9GjTw3fTH5DV%2Fq0sCYzdsQOvNdJaKufP8Q2yYkwjE%2B%2BSYc38wIIXpQXhIa2xnQUwgVzl%2BvGA3Xe5mwTG6nqMg0aqrMZsFVyV5v%2Fy066GSpphKwm61S8yBusLbO1hkWyba99GaYjLt7bx66GVD1qGYBR59Z6D5H5K3iaOt1qLgaTy8D1JOPJMKBr%2B2EVbED0msx7KlEadIM5%2BvqRkl7wRAnCmh14upxGoctRzhHf0bi%2Beet7yH9Aq6%2FAWcqMulYHfzs2dPVuE292BKG6fxhSdCXPBIOfY13bJeZ6Yw%2FrlLIgdQTFDX%2B4kLoww4uWlAY6pQHOBU1PaXC7w%2Bq5%2BYn2D0rbZG7gX83i4q3oyv9lx3Fyrd2cwARgZHUOnJrjP%2FjFOAiffm0quBH4duHuNzRvCDJlgDfkzqaWSfOMn2mKE5Er0m2UCtzrzK30af%2B3Du01INuSAzhaLZ%2F9eoxPKBIcNObtEM5VkcLueBNw0b%2FJgaagVNZARovovI2Ts6sad3H%2FJI%2B85y0WOb14bCrTr2IxO0SFlMxTVFc%3D&X-Amz-Signature=46c035afff7a26eacd5780ec977037bd40da2fefad5d4c8150170a938b7418c6';
+  return 'https://umccr-temp-dev.s3.ap-southeast-2.amazonaws.com/william/test-head.tsv?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIA4IXYHPYNGAMPUGH3%2F20220519%2Fap-southeast-2%2Fs3%2Faws4_request&X-Amz-Date=20220519T005208Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEAgaDmFwLXNvdXRoZWFzdC0yIkgwRgIhAOYmByZSzrHjwPEBA1RBk8whXCcmfm05Me8AmijUlZ%2B1AiEAkzTbUCoapcP3tbFaY3yqnMiEL4DiGUNNFBoVu8aKYvsqoQMI4f%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARADGgw4NDM0MDc5MTY1NzAiDFtMI%2F7IevQQnLESNSr1AnorHEMrHV9NIr4E%2FsX82gOZT9SS%2BZfvcXVrAavvNXpZ8Svr0c7krNUmmqcGoePOx%2FRVq0ixVAs2ipcPOpj01KAaoyHk0HfleFR%2Bjd1kv8gsIHKni7wK%2FL7lpsJa32JXCrTqsP%2FSGCQbRwOgt3vaV2w4nqocYDLgJkRRQxGjV1s3LANgEO0Kg51qXntua9GjTw3fTH5DV%2Fq0sCYzdsQOvNdJaKufP8Q2yYkwjE%2B%2BSYc38wIIXpQXhIa2xnQUwgVzl%2BvGA3Xe5mwTG6nqMg0aqrMZsFVyV5v%2Fy066GSpphKwm61S8yBusLbO1hkWyba99GaYjLt7bx66GVD1qGYBR59Z6D5H5K3iaOt1qLgaTy8D1JOPJMKBr%2B2EVbED0msx7KlEadIM5%2BvqRkl7wRAnCmh14upxGoctRzhHf0bi%2Beet7yH9Aq6%2FAWcqMulYHfzs2dPVuE292BKG6fxhSdCXPBIOfY13bJeZ6Yw%2FrlLIgdQTFDX%2B4kLoww4uWlAY6pQHOBU1PaXC7w%2Bq5%2BYn2D0rbZG7gX83i4q3oyv9lx3Fyrd2cwARgZHUOnJrjP%2FjFOAiffm0quBH4duHuNzRvCDJlgDfkzqaWSfOMn2mKE5Er0m2UCtzrzK30af%2B3Du01INuSAzhaLZ%2F9eoxPKBIcNObtEM5VkcLueBNw0b%2FJgaagVNZARovovI2Ts6sad3H%2FJI%2B85y0WOb14bCrTr2IxO0SFlMxTVFc%3D&X-Amz-Signature=fbc6f181b36f3d44b2d1e23528ee01cf3389f8b3f777fe6d6e95833f6ffe7fa2';
   const apiResponse = await API.get('files', `/gds/${id}/presign`, {});
 
   if (Object.keys(apiResponse).includes('error')) {
@@ -170,13 +178,17 @@ function ImageViewer({ presignedUrl }: ImageViewerProps) {
   return <img style={{ maxHeight: '100%', maxWidth: '100%' }} src={presignedUrl} />;
 }
 
-type HTMLViewersProps = { fileContent: string };
-function HTMLViewers({ fileContent }: HTMLViewersProps) {
+type HTMLViewerProps = { fileContent: string };
+function HTMLViewer({ fileContent }: HTMLViewerProps) {
   return <iframe style={{ height: '80vh', width: '100%' }} srcDoc={fileContent} />;
 }
 
-type CSVViewersProps = { fileContent: string };
-function CSVViewers({ fileContent }: CSVViewersProps) {
+type DelimiterSeperatedValuesViewerProps = {
+  fileContent: string;
+  delimiter: string;
+};
+function DelimiterSeperatedValuesViewer(props: DelimiterSeperatedValuesViewerProps) {
+  const { fileContent, delimiter } = props;
   const [isFirstRowHeader, setIsFirstRowHeader] = useState<boolean>(true);
 
   // Sanitize and split string
@@ -208,7 +220,7 @@ function CSVViewers({ fileContent }: CSVViewersProps) {
             <TableHead>
               {headerRow ? (
                 <TableRow>
-                  {headerRow.split(',').map((column: string) => (
+                  {headerRow.split(delimiter).map((column: string) => (
                     <TableCell key={column}>{column}</TableCell>
                   ))}
                 </TableRow>
@@ -221,67 +233,7 @@ function CSVViewers({ fileContent }: CSVViewersProps) {
               {dataRows.map((row: string, index: number) => {
                 return (
                   <TableRow hover role='checkbox' tabIndex={-1} key={index}>
-                    {row.split(',').map((value: string, index: number) => {
-                      return <TableCell key={index}>{value}</TableCell>;
-                    })}
-                  </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      </Paper>
-    </div>
-  );
-}
-
-type TSVViewersProps = { fileContent: string };
-function TSVViewers({ fileContent }: TSVViewersProps) {
-  const [isFirstRowHeader, setIsFirstRowHeader] = useState<boolean>(true);
-
-  // Sanitize and split string
-  const sanitizeContent: string = fileContent.replaceAll('\r\n', '\n');
-  const allRows: string[] = sanitizeContent.split('\n').filter((element) => element);
-
-  const dataRows = allRows.slice(isFirstRowHeader ? 1 : 0);
-  const headerRow = isFirstRowHeader ? allRows[0] : null;
-
-  return (
-    <div style={{ width: '100%' }}>
-      <FormControlLabel
-        value='end'
-        control={
-          <Checkbox
-            color='primary'
-            size='small'
-            checked={isFirstRowHeader}
-            onChange={() => setIsFirstRowHeader((prev) => !prev)}
-          />
-        }
-        label='Header row'
-        labelPlacement='end'
-        style={{ marginBottom: '0.5rem' }}
-      />
-      <Paper elevation={3} style={{ width: '100%' }}>
-        <TableContainer style={{ maxHeight: '75vh' }}>
-          <Table stickyHeader aria-label='sticky table'>
-            <TableHead>
-              {headerRow ? (
-                <TableRow>
-                  {headerRow.split('\t').map((column: string) => (
-                    <TableCell key={column}>{column}</TableCell>
-                  ))}
-                </TableRow>
-              ) : (
-                <></>
-              )}
-            </TableHead>
-
-            <TableBody>
-              {dataRows.map((row: string, index: number) => {
-                return (
-                  <TableRow hover role='checkbox' tabIndex={-1} key={index}>
-                    {row.split('\t').map((value: string, index: number) => {
+                    {row.split(delimiter).map((value: string, index: number) => {
                       return <TableCell key={index}>{value}</TableCell>;
                     })}
                   </TableRow>

--- a/src/components/PreviewActionButton.tsx
+++ b/src/components/PreviewActionButton.tsx
@@ -267,12 +267,22 @@ async function getPreSignedUrlBody(url: string) {
  */
 type ImageViewerProps = { presignedUrl: string };
 function ImageViewer({ presignedUrl }: ImageViewerProps) {
-  return <img style={{ maxHeight: '100%', maxWidth: '100%' }} src={presignedUrl} />;
+  return (
+    <img
+      style={{ maxHeight: '100%', maxWidth: '100%', backgroundColor: 'white' }}
+      src={presignedUrl}
+    />
+  );
 }
 
 type HTMLViewerProps = { fileContent: string };
 function HTMLViewer({ fileContent }: HTMLViewerProps) {
-  return <iframe style={{ height: '80vh', width: '100%' }} srcDoc={fileContent} />;
+  return (
+    <iframe
+      style={{ height: '80vh', width: '100%', backgroundColor: 'white' }}
+      srcDoc={fileContent}
+    />
+  );
 }
 
 type DelimiterSeperatedValuesViewerProps = {
@@ -291,7 +301,7 @@ function DelimiterSeperatedValuesViewer(props: DelimiterSeperatedValuesViewerPro
   const headerRow = isFirstRowHeader ? allRows[0] : null;
 
   return (
-    <div style={{ width: '100%' }}>
+    <Paper style={{ width: '100%', background: 'white', padding: '1rem' }}>
       <FormControlLabel
         value='end'
         control={
@@ -335,7 +345,7 @@ function DelimiterSeperatedValuesViewer(props: DelimiterSeperatedValuesViewerPro
           </Table>
         </TableContainer>
       </Paper>
-    </div>
+    </Paper>
   );
 }
 

--- a/src/containers/Subject.js
+++ b/src/containers/Subject.js
@@ -56,6 +56,7 @@ import ListItemText from '@material-ui/core/ListItemText';
 import List from '@material-ui/core/List';
 import MenuBookIcon from '@material-ui/icons/MenuBook';
 import LaunchPadDialog from '../components/LaunchPadDialog';
+import PreviewActionButton from '../components/PreviewActionButton';
 
 const styles = (theme) => ({
   close: {
@@ -1121,6 +1122,7 @@ class Subject extends Component {
     const columns = [
       { key: 'volume_name', sortable: true },
       { key: 'path', sortable: true },
+      { key: 'preview', sortable: false },
       { key: 'actions', sortable: false },
       { key: 'size', sortable: true, label: 'size_in_bytes' },
       { key: 'time_modified', sortable: true },
@@ -1177,6 +1179,8 @@ class Subject extends Component {
                         <HumanReadableFileSize bytes={row[col.label]} />
                       ) : col.key === 'time_modified' ? (
                         <Moment local>{row[col.key]}</Moment>
+                      ) : col.key === 'preview' ? (
+                        <PreviewActionButton data={row} />
                       ) : (
                         row[col.key]
                       )}

--- a/src/containers/Subject.js
+++ b/src/containers/Subject.js
@@ -674,6 +674,7 @@ class Subject extends Component {
   renderResultTable = (title, data, label) => {
     const columns = [
       { key: 'key', sortable: true },
+      { key: 'preview', sortable: true },
       { key: 'actions', sortable: false },
       { key: 'size', sortable: true },
       { key: 'last_modified_date', sortable: true },
@@ -700,6 +701,8 @@ class Subject extends Component {
                     <HumanReadableFileSize bytes={row[col.key]} />
                   ) : col.key === 'last_modified_date' ? (
                     <Moment local>{row[col.key]}</Moment>
+                  ) : col.key === 'preview' ? (
+                    <PreviewActionButton type='s3' data={row} />
                   ) : (
                     row[col.key]
                   )}
@@ -857,6 +860,7 @@ class Subject extends Component {
     const columns = [
       { key: 'bucket', sortable: true },
       { key: 'key', sortable: true },
+      { key: 'preview', sortable: false },
       { key: 'actions', sortable: false },
       { key: 'size', sortable: true },
       { key: 'last_modified_date', sortable: true },
@@ -913,6 +917,8 @@ class Subject extends Component {
                         <HumanReadableFileSize bytes={row[col.key]} />
                       ) : col.key === 'last_modified_date' ? (
                         <Moment local>{row[col.key]}</Moment>
+                      ) : col.key === 'preview' ? (
+                        <PreviewActionButton type='s3' data={row} />
                       ) : (
                         row[col.key]
                       )}
@@ -1180,7 +1186,7 @@ class Subject extends Component {
                       ) : col.key === 'time_modified' ? (
                         <Moment local>{row[col.key]}</Moment>
                       ) : col.key === 'preview' ? (
-                        <PreviewActionButton data={row} />
+                        <PreviewActionButton type='gds' data={row} />
                       ) : (
                         row[col.key]
                       )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9908,6 +9908,13 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.1.0.tgz#61aaed3096d30eacf2a2127118b5b41387d32a67"
   integrity sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==
 
+react-json-pretty@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-json-pretty/-/react-json-pretty-2.2.0.tgz#9ba907d2b08d87e90456d87b6025feeceb8f63cf"
+  integrity sha512-3UMzlAXkJ4R8S4vmkRKtvJHTewG4/rn1Q18n0zqdu/ipZbUPLVZD+QwC7uVcD/IAY3s8iNVHlgR2dMzIUS0n1A==
+  dependencies:
+    prop-types "^15.6.2"
+
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"


### PR DESCRIPTION
Added PresignedURL Preview button (beside on the `Action (Menu Icon)` button) in SubjectData (`GDS` and `S3`) and AnalysisResults Tabs. 

List of extension supported:
- png, jpg, jpeg
- html
- csv
- tsv
- md5sum
- txt
- JSON
- yaml