### PR TITLE
Change SignIn function

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -208,7 +208,7 @@ class App extends Component {
           authUserInfo={authUserInfo}
           handleLogOutClicked={this.handleLogOutClicked}
           handleDrawerToggle={this.handleDrawerToggle}
-          handleSignIn={this.props.OAuthSignIn}
+          handleSignIn={() => Auth.federatedSignIn({ provider: 'Google' })}
           handleSignOut={this.handleSignOut}
           title={
             <Switch>
@@ -260,7 +260,7 @@ class App extends Component {
   }
 
   renderLanding() {
-    return <LandingPage handleSignIn={this.props.OAuthSignIn} />;
+    return <LandingPage handleSignIn={() => Auth.federatedSignIn({ provider: 'Google' })} />;
   }
 
   render() {


### PR DESCRIPTION
Specifying `Google` as the Identity Provider. This will allow to skip the `Sign In with your social account` page (which only has one button to press).

<img width="200" alt="Screen Shot 2022-05-20 at 3 13 43 pm" src="https://user-images.githubusercontent.com/61998484/169455282-63b0f76d-e382-4481-bb01-285a27c73b2e.png">
