### PR TITLE
Update preview button

### DIFF
--- a/src/components/PreviewActionButton.tsx
+++ b/src/components/PreviewActionButton.tsx
@@ -5,7 +5,6 @@ import { API } from 'aws-amplify';
 
 // Material- UI
 import CloseIcon from '@material-ui/icons/Close';
-import AllOutIcon from '@material-ui/icons/AllOut';
 import WarningIcon from '@material-ui/icons/Warning';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import IconButton from '@material-ui/core/IconButton';
@@ -36,34 +35,11 @@ const OTHER_FILETYPE_LIST: string[] = ['html', 'json', 'yaml'];
 /**
  * Preview Action Button
  */
-const useStylesButtonIcon = makeStyles({
-  typeWarning: {
-    position: 'relative',
-    '& p': {
-      display: 'none',
-      width: '100%',
-    },
-    '&:hover': {
-      '& p': {
-        backgroundColor: 'white',
-        border: '1px solid black',
-        position: 'absolute',
-        display: 'inline',
-        width: 'max-content',
-        top: '-2.2rem',
-        left: '-100%',
-        padding: '3px',
-      },
-    },
-  },
-});
 type PreviewActionButtonProps = {
   type: string;
   data: any;
 };
 export default function PreviewActionButton({ type, data }: PreviewActionButtonProps) {
-  const iconClasses = useStylesButtonIcon();
-
   const fileName = type == 'gds' ? data.name : data.key;
   const fileSize = type == 'gds' ? data.size_in_bytes : data.size;
   const isDataTypeSupported = checkIsDataTypeSupoorted(fileName);
@@ -71,28 +47,8 @@ export default function PreviewActionButton({ type, data }: PreviewActionButtonP
 
   const [isPreviewOpen, setIsPreviewOpen] = useState<boolean>(false);
 
-  if (!isDataTypeSupported) {
-    return (
-      <div className={iconClasses.typeWarning}>
-        <IconButton disabled={true}>
-          <WarningIcon />
-        </IconButton>
-
-        {/* Text will show on hover defined on div class */}
-        <p>Unsupported FileType</p>
-      </div>
-    );
-  } else if (!isFileSizeSupported) {
-    return (
-      <div className={iconClasses.typeWarning}>
-        <IconButton disabled={true}>
-          <AllOutIcon />
-        </IconButton>
-
-        {/* Text will show on hover defined on div class */}
-        <p>FileSize exceed 15MB</p>
-      </div>
-    );
+  if (!isDataTypeSupported || !isFileSizeSupported) {
+    return <div />;
   } else {
     return (
       <>
@@ -215,7 +171,13 @@ function DialogData({ type, data }: DialogDataProps) {
           overflow: 'hidden',
         }}>
         {presignedUrlData.isLoading ? (
-          <div style={{ minHeight: '30vh' }}>
+          <div
+            style={{
+              minHeight: '30vh',
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+            }}>
             <CircularProgress />
           </div>
         ) : presignedUrlData.isError ? (

--- a/src/components/PreviewActionButton.tsx
+++ b/src/components/PreviewActionButton.tsx
@@ -28,9 +28,14 @@ import { Typography } from '@material-ui/core';
 import JSONPretty from 'react-json-pretty';
 
 const IMAGE_FILETYPE_LIST: string[] = ['png', 'jpg', 'jpeg'];
-const DELIMITER_SERPERATED_VALUE_FILETYPE_LIST: string[] = ['csv', 'tsv'];
-const PLAIN_FILETYPE_LIST: string[] = ['txt', 'md5sum'];
-const OTHER_FILETYPE_LIST: string[] = ['html', 'json', 'yaml'];
+
+/**
+ * For Temporary only support Image filetype
+ * TODO: Uncomment the following constants below
+ */
+// const DELIMITER_SERPERATED_VALUE_FILETYPE_LIST: string[] = ['csv', 'tsv'];
+// const PLAIN_FILETYPE_LIST: string[] = ['txt', 'md5sum'];
+// const OTHER_FILETYPE_LIST: string[] = ['html', 'json', 'yaml'];
 
 /**
  * Preview Action Button
@@ -77,9 +82,15 @@ export default function PreviewActionButton({ type, data }: PreviewActionButtonP
 function checkIsDataTypeSupoorted(name: string): boolean {
   const dataTypeSupported = [
     ...IMAGE_FILETYPE_LIST,
-    ...DELIMITER_SERPERATED_VALUE_FILETYPE_LIST,
-    ...PLAIN_FILETYPE_LIST,
-    ...OTHER_FILETYPE_LIST,
+
+    /**
+     * For Temporary only support Image filetype
+     * TODO: Uncomment the following constants below
+     */
+
+    // ...DELIMITER_SERPERATED_VALUE_FILETYPE_LIST,
+    // ...PLAIN_FILETYPE_LIST,
+    // ...OTHER_FILETYPE_LIST,
   ];
 
   for (const dataType of dataTypeSupported) {

--- a/src/components/PreviewActionButton.tsx
+++ b/src/components/PreviewActionButton.tsx
@@ -224,6 +224,7 @@ function DialogData({ type, data }: DialogDataProps) {
           alignItems: 'center',
           backgroundColor: '#525659',
           overflow: 'hidden',
+          padding: '1px 0 0 0',
         }}>
         {presignedUrlData.isLoading ? (
           <div
@@ -240,7 +241,7 @@ function DialogData({ type, data }: DialogDataProps) {
         ) : IMAGE_FILETYPE_LIST.includes(fileType) ? (
           <ImageViewer presignedUrl={presignedUrlData.presignedUrlString} />
         ) : HTML_FILETYPE_LIST.includes(fileType) ? (
-          <HTMLViewer preSignedUrl={presignedUrlData.presignedUrlString} />
+          <HTMLViewer presignedUrl={presignedUrlData.presignedUrlString} />
         ) : fileType === 'csv' ? (
           <DelimiterSeperatedValuesViewer
             fileContent={presignedUrlData.presignedUrlContent}
@@ -301,12 +302,12 @@ function ImageViewer({ presignedUrl }: ImageViewerProps) {
   );
 }
 
-type HTMLViewerProps = { preSignedUrl: string };
-function HTMLViewer({ preSignedUrl }: HTMLViewerProps) {
+type HTMLViewerProps = { presignedUrl: string };
+function HTMLViewer({ presignedUrl }: HTMLViewerProps) {
   return (
     <iframe
       style={{ height: '80vh', width: '100%', backgroundColor: 'white' }}
-      src={preSignedUrl}
+      src={presignedUrl}
     />
   );
 }

--- a/src/components/PreviewActionButton.tsx
+++ b/src/components/PreviewActionButton.tsx
@@ -35,7 +35,7 @@ const IMAGE_FILETYPE_LIST: string[] = ['png', 'jpg', 'jpeg'];
  */
 // const DELIMITER_SERPERATED_VALUE_FILETYPE_LIST: string[] = ['csv', 'tsv'];
 // const PLAIN_FILETYPE_LIST: string[] = ['txt', 'md5sum'];
-// const OTHER_FILETYPE_LIST: string[] = ['html', 'json', 'yaml'];
+// const OTHER_FILETYPE_LIST: string[] = ['json', 'yaml'];
 
 /**
  * Preview Action Button
@@ -139,7 +139,7 @@ function DialogData({ type, data }: DialogDataProps) {
 
         // Skip stream data if an image file
         let presignedUrlContent = '';
-        if (!IMAGE_FILETYPE_LIST.includes(fileType) && 'html' != fileType) {
+        if (!IMAGE_FILETYPE_LIST.includes(fileType)) {
           presignedUrlContent = await getPreSignedUrlBody(presignedUrlString);
         }
         if (componentUnmount) return;
@@ -195,8 +195,6 @@ function DialogData({ type, data }: DialogDataProps) {
           <WarningIcon fontSize='large' style={{ minHeight: '30vh' }} />
         ) : IMAGE_FILETYPE_LIST.includes(fileType) ? (
           <ImageViewer presignedUrl={presignedUrlData.presignedUrlString} />
-        ) : fileType === 'html' ? (
-          <HTMLViewer preSignedUrl={presignedUrlData.presignedUrlString} />
         ) : fileType === 'csv' ? (
           <DelimiterSeperatedValuesViewer
             fileContent={presignedUrlData.presignedUrlContent}
@@ -254,16 +252,6 @@ function ImageViewer({ presignedUrl }: ImageViewerProps) {
         src={presignedUrl}
       />
     </div>
-  );
-}
-
-type HTMLViewerProps = { preSignedUrl: string };
-function HTMLViewer({ preSignedUrl }: HTMLViewerProps) {
-  return (
-    <iframe
-      style={{ height: '80vh', width: '100%', backgroundColor: 'white' }}
-      src={preSignedUrl}
-    />
   );
 }
 

--- a/src/components/PreviewActionButton.tsx
+++ b/src/components/PreviewActionButton.tsx
@@ -34,9 +34,9 @@ const HTML_FILETYPE_LIST: string[] = ['html'];
  * For Temporary only support Image filetype due to cors-origin policy
  * TODO: Uncomment the following constants below
  */
-const DELIMITER_SERPERATED_VALUE_FILETYPE_LIST: string[] = ['csv', 'tsv'];
-const PLAIN_FILETYPE_LIST: string[] = ['txt', 'md5sum'];
-const OTHER_FILETYPE_LIST: string[] = ['json', 'yaml'];
+// const DELIMITER_SERPERATED_VALUE_FILETYPE_LIST: string[] = ['csv', 'tsv'];
+// const PLAIN_FILETYPE_LIST: string[] = ['txt', 'md5sum'];
+// const OTHER_FILETYPE_LIST: string[] = ['json', 'yaml'];
 
 /**
  * Preview Action Button
@@ -131,9 +131,9 @@ function checkIsDataTypeSupoorted(name: string): boolean {
      * For Temporary only support Image filetype due to cors-origin policy
      * TODO: Uncomment the following constants below
      */
-    ...DELIMITER_SERPERATED_VALUE_FILETYPE_LIST,
-    ...PLAIN_FILETYPE_LIST,
-    ...OTHER_FILETYPE_LIST,
+    // ...DELIMITER_SERPERATED_VALUE_FILETYPE_LIST,
+    // ...PLAIN_FILETYPE_LIST,
+    // ...OTHER_FILETYPE_LIST,
   ];
 
   for (const dataType of dataTypeSupported) {

--- a/src/components/PreviewActionButton.tsx
+++ b/src/components/PreviewActionButton.tsx
@@ -23,6 +23,7 @@ import TableRow from '@material-ui/core/TableRow';
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import { makeStyles } from '@material-ui/core/styles';
+import { Typography } from '@material-ui/core';
 
 // Other Dependencies
 import JSONPretty from 'react-json-pretty';
@@ -171,7 +172,7 @@ function DialogData({ type, data }: DialogDataProps) {
 
         // Skip stream data if an image file
         let presignedUrlContent = '';
-        if (!IMAGE_FILETYPE_LIST.includes(fileType)) {
+        if (!IMAGE_FILETYPE_LIST.includes(fileType) && 'html' != fileType) {
           presignedUrlContent = await getPreSignedUrlBody(presignedUrlString);
         }
         if (componentUnmount) return;
@@ -200,7 +201,11 @@ function DialogData({ type, data }: DialogDataProps) {
   return (
     <>
       {/* Dialog that opens the preview */}
-      <DialogTitle style={{ minHeight: '4rem' }}>{fileName}</DialogTitle>
+      <DialogTitle style={{ minHeight: '4rem' }}>
+        <Typography variant='h6' noWrap>
+          {fileName}
+        </Typography>
+      </DialogTitle>
       <DialogContent
         style={{
           display: 'flex',
@@ -218,7 +223,7 @@ function DialogData({ type, data }: DialogDataProps) {
         ) : IMAGE_FILETYPE_LIST.includes(fileType) ? (
           <ImageViewer presignedUrl={presignedUrlData.presignedUrlString} />
         ) : fileType === 'html' ? (
-          <HTMLViewer fileContent={presignedUrlData.presignedUrlContent} />
+          <HTMLViewer preSignedUrl={presignedUrlData.presignedUrlString} />
         ) : fileType === 'csv' ? (
           <DelimiterSeperatedValuesViewer
             fileContent={presignedUrlData.presignedUrlContent}
@@ -268,19 +273,23 @@ async function getPreSignedUrlBody(url: string) {
 type ImageViewerProps = { presignedUrl: string };
 function ImageViewer({ presignedUrl }: ImageViewerProps) {
   return (
-    <img
-      style={{ maxHeight: '100%', maxWidth: '100%', backgroundColor: 'white' }}
-      src={presignedUrl}
-    />
+    <div
+      style={{ height: '80vh', maxWidth: '100%' }}
+      onClick={() => window.open(presignedUrl, '_blank')}>
+      <img
+        style={{ maxHeight: '100%', maxWidth: '100%', backgroundColor: 'white' }}
+        src={presignedUrl}
+      />
+    </div>
   );
 }
 
-type HTMLViewerProps = { fileContent: string };
-function HTMLViewer({ fileContent }: HTMLViewerProps) {
+type HTMLViewerProps = { preSignedUrl: string };
+function HTMLViewer({ preSignedUrl }: HTMLViewerProps) {
   return (
     <iframe
       style={{ height: '80vh', width: '100%', backgroundColor: 'white' }}
-      srcDoc={fileContent}
+      src={preSignedUrl}
     />
   );
 }


### PR DESCRIPTION
- Image re-sizing to fit Dialog component
- Suspend all filetype preview **except** images and HTML (PNG, JPG, JPEG, HTML), due to `cors-origin-policy`


NOTE: It will be squashed merge (Ignore the lousy git commit messages 😉)