### PR TITLE
Add`.png` file previewer page

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -10,7 +10,7 @@ import LandingPage from './containers/LandingPage';
 import Subject from './containers/Subject';
 import Run from './containers/Run';
 import IGV from './containers/IGV';
-import FilesViewers from './containers/FileViewers';
+import FilesViewers from './containers/FileViewer';
 
 class Routes extends Component {
   render() {

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -10,6 +10,7 @@ import LandingPage from './containers/LandingPage';
 import Subject from './containers/Subject';
 import Run from './containers/Run';
 import IGV from './containers/IGV';
+import FilesViewers from './containers/FileViewers';
 
 class Routes extends Component {
   render() {
@@ -33,6 +34,7 @@ class Routes extends Component {
             <Route path='/storage' component={Storage} />
             <Route path='/igv' exact component={IGV} />
             <Route path='/igv/:subjectId' exact component={IGV} />
+            <Route path='/files/:subjectId' exact component={FilesViewers} />
           </Fragment>
         )}
       </Switch>

--- a/src/containers/FileViewer.tsx
+++ b/src/containers/FileViewer.tsx
@@ -366,24 +366,33 @@ function FetchAndShowFile(props: FetchAndShowFileProps) {
   // Dialog to see more details
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
+  // IsError Component
+  const [isError, setIsError] = useState(false);
+
   useEffect(() => {
     let componentUnmount = false;
 
     const fetchPresignedUrl = async () => {
       const id = selectedPreview.id;
-      const presigned_url = await getPreSignedUrl(id);
+      try {
+        const presigned_url = await getPreSignedUrl(id);
 
-      handleChangeResult((prev: any) => {
-        const newState = { ...prev };
+        if (componentUnmount) return;
+        handleChangeResult((prev: any) => {
+          const newState = { ...prev };
 
-        for (const item of newState.items) {
-          if (item.id === selectedPreview.id) {
-            item['presigned_url'] = presigned_url;
+          for (const item of newState.items) {
+            if (item.id === selectedPreview.id) {
+              item['presigned_url'] = presigned_url;
+            }
           }
-        }
-        return newState;
-      });
-      if (componentUnmount) return;
+          return newState;
+        });
+      } catch (e) {
+        if (componentUnmount) return;
+        setIsError(true);
+        return;
+      }
     };
     if (!selectedPreview.presigned_url) {
       fetchPresignedUrl();
@@ -395,7 +404,9 @@ function FetchAndShowFile(props: FetchAndShowFileProps) {
 
   return (
     <>
-      {!selectedPreview.presigned_url ? (
+      {isError ? (
+        <WarningIcon />
+      ) : !selectedPreview.presigned_url ? (
         <CircularProgress />
       ) : (
         <Grid item style={{ maxHeight: '100%', position: 'unset', padding: '1rem' }}>

--- a/src/containers/FileViewer.tsx
+++ b/src/containers/FileViewer.tsx
@@ -40,7 +40,7 @@ const GPL_PIPELINE_OPTIONS: pipelineOptionType[] = [
 ];
 
 const UMCCRISED_PIPELINE_OPTIONS: pipelineOptionType[] = [
-  { name: 'UMCCRISED - all', regexKey: 'umccrised/(.*)(.png$)' },
+  { name: 'UMCCRISE - all', regexKey: 'umccrised/(.*)(.png$)' },
 ];
 const DEFAULT_PIPELINE_OPTIONS: pipelineOptionType = { name: 'All', regexKey: '(.*)(.png$)' };
 
@@ -50,7 +50,7 @@ const PIPELINE_OPTIONS_LIST: pipelineOptionType[] = [
   ...UMCCRISED_PIPELINE_OPTIONS,
 ];
 
-function FileViewers() {
+function FileViewer() {
   // Parse subjectId from url
   const { subjectId } = useParams<{ subjectId: string }>();
 
@@ -386,4 +386,4 @@ async function getPreSignedUrl(id: string) {
   return signed_url;
 }
 
-export default FileViewers;
+export default FileViewer;

--- a/src/containers/FileViewers.tsx
+++ b/src/containers/FileViewers.tsx
@@ -12,16 +12,21 @@ import {
   MenuItem,
   FormControl,
   Select,
+  ImageListItemBar,
 } from '@material-ui/core';
 import { grey } from '@material-ui/core/colors';
 
 // MUI - Icons
 import ChevronLeft from '@material-ui/icons/ChevronLeft';
 import WarningIcon from '@material-ui/icons/Warning';
+import InfoIcon from '@material-ui/icons/Info';
 
 // Other libraries
 import { useParams, Link } from 'react-router-dom';
 import { API } from 'aws-amplify';
+
+// Import dialog details
+import LimsRowDetailsDialog from '../components/LimsRowDetailsDialog';
 
 type pipelineOptionType = {
   name: string;
@@ -75,6 +80,9 @@ function FileViewers() {
   if (selectedPreview == null && apiResults.items.length !== 0) {
     setSelectedPreview(apiResults.items[0]);
   }
+
+  // Dialog to see more details
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   useEffect(() => {
     let componentUnmount = false;
@@ -291,22 +299,48 @@ function FileViewers() {
               </Grid>
               <Grid
                 item
+                container
                 xs={8}
                 style={{
                   borderLeft: `1pt solid ${grey[300]}`,
                   height: '100%',
-                  display: 'flex',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                }}>
+                  position: 'relative',
+                  backgroundColor: `${grey[500]}`,
+                }}
+                direction='column'
+                justifyContent='center'
+                alignItems='center'>
                 {selectedPreview == null ? (
                   <CircularProgress />
                 ) : (
-                  <img
-                    style={{ maxHeight: '100%', maxWidth: '100%', backgroundColor: 'white' }}
-                    onClick={() => window.open(selectedPreview.presignedUrl, '_blank')}
-                    src={selectedPreview.presignedUrl}
-                  />
+                  <Grid item style={{ maxHeight: '100%', position: 'unset', padding: '1rem' }}>
+                    <div style={{ height: '48px' }}>
+                      <LimsRowDetailsDialog
+                        dialogOpened={isDialogOpen}
+                        rowData={selectedPreview}
+                        onDialogClose={() => setIsDialogOpen(false)}
+                      />
+                      <ImageListItemBar
+                        position='top'
+                        title={selectedPreview.key}
+                        actionIcon={
+                          <IconButton onClick={() => setIsDialogOpen(true)}>
+                            <InfoIcon />
+                          </IconButton>
+                        }
+                      />
+                    </div>
+                    <img
+                      style={{
+                        maxHeight: 'calc(100% - 48px)',
+                        maxWidth: '100%',
+                        backgroundColor: 'white',
+                        padding: '1px',
+                      }}
+                      onClick={() => window.open(selectedPreview.presigned_url, '_blank')}
+                      src={selectedPreview.presigned_url}
+                    />
+                  </Grid>
                 )}
               </Grid>
             </Grid>
@@ -320,8 +354,8 @@ function FileViewers() {
 async function getPresignedUrlForEveryItem(apiResponse: any) {
   for (const item of apiResponse.results) {
     const id = item.id;
-    const presignedUrl = await getPreSignedUrl(id);
-    item['presignedUrl'] = presignedUrl;
+    const presigned_url = await getPreSignedUrl(id);
+    item['presigned_url'] = presigned_url;
   }
 }
 

--- a/src/containers/FileViewers.tsx
+++ b/src/containers/FileViewers.tsx
@@ -1,0 +1,337 @@
+import React, { useState, useEffect } from 'react';
+
+// MUI - Components
+import {
+  Paper,
+  Grid,
+  Typography,
+  IconButton,
+  CircularProgress,
+  ButtonBase,
+  InputLabel,
+  MenuItem,
+  FormControl,
+  Select,
+} from '@material-ui/core';
+import { grey } from '@material-ui/core/colors';
+
+// MUI - Icons
+import ChevronLeft from '@material-ui/icons/ChevronLeft';
+import WarningIcon from '@material-ui/icons/Warning';
+
+// Other libraries
+import { useParams, Link } from 'react-router-dom';
+import { API } from 'aws-amplify';
+
+type pipelineOptionType = {
+  name: string;
+  regexKey: string;
+};
+
+const GPL_PIPELINE_OPTIONS: pipelineOptionType[] = [
+  { name: 'GPL - all', regexKey: 'gridss_purple_linx/(.*)(.png$)' },
+  { name: 'GPL - purple', regexKey: 'gridss_purple_linx/purple/(.*)(.png$)' },
+  { name: 'GPL - linx', regexKey: 'gridss_purple_linx/linx/(.*)(.png$)' },
+];
+
+const UMCCRISED_PIPELINE_OPTIONS: pipelineOptionType[] = [
+  { name: 'UMCCRISED - all', regexKey: 'umccrised/(.*)(.png$)' },
+];
+const DEFAULT_PIPELINE_OPTIONS: pipelineOptionType = { name: 'All', regexKey: '(.*)(.png$)' };
+
+const PIPELINE_OPTIONS_LIST: pipelineOptionType[] = [
+  DEFAULT_PIPELINE_OPTIONS,
+  ...GPL_PIPELINE_OPTIONS,
+  ...UMCCRISED_PIPELINE_OPTIONS,
+];
+
+function FileViewers() {
+  // Parse subjectId from url
+  const { subjectId } = useParams<{ subjectId: string }>();
+
+  // REGEX field
+  const [pipelineSelection, setpipelineSelection] =
+    useState<pipelineOptionType>(DEFAULT_PIPELINE_OPTIONS);
+  const handleSelectionChange = (event: React.ChangeEvent<{ value: any }>) => {
+    setpipelineSelection(JSON.parse(event.target.value));
+  };
+
+  // API Responses
+  type apiDataResultType = {
+    isLoading: boolean;
+    isError: boolean;
+    nextPageLink: string | null;
+    items: any[];
+  };
+  const [apiResults, setApiResults] = useState<apiDataResultType>({
+    isLoading: true,
+    isError: false,
+    nextPageLink: null,
+    items: [],
+  });
+  const [queryNextUrlString, setQueryNextUrlString] = useState<string | null>(null);
+
+  const [selectedPreview, setSelectedPreview] = useState<any>(null);
+  if (selectedPreview == null && apiResults.items.length !== 0) {
+    setSelectedPreview(apiResults.items[0]);
+  }
+
+  useEffect(() => {
+    let componentUnmount = false;
+    const fetchData = async () => {
+      setApiResults((prev) => ({
+        ...prev,
+        isLoading: true,
+      }));
+
+      // Build API-config
+      let apiConfig = {};
+      apiConfig = {
+        queryStringParameters: {
+          subject: `${subjectId}`,
+          search: pipelineSelection.regexKey,
+          rowsPerPage: 10,
+          ordering: 'key',
+        },
+      };
+      try {
+        const apiResponse = await API.get('files', '/s3', apiConfig);
+        await getPresignedUrlForEveryItem(apiResponse);
+        setApiResults({
+          isLoading: false,
+          isError: false,
+          nextPageLink: apiResponse.links.next,
+          items: apiResponse.results,
+        });
+      } catch {
+        if (componentUnmount) return;
+        setApiResults((prev) => ({
+          ...prev,
+          isLoading: false,
+          isError: true,
+        }));
+      }
+
+      setSelectedPreview(null);
+      setQueryNextUrlString(null);
+    };
+
+    fetchData();
+
+    return () => {
+      componentUnmount = true;
+    };
+  }, [pipelineSelection]);
+
+  useEffect(() => {
+    let componentUnmount = false;
+    const fetchData = async (queryNextUrlString: string) => {
+      setApiResults((prev) => ({
+        ...prev,
+        isLoading: true,
+      }));
+      try {
+        const queryString = queryNextUrlString.split('?').pop();
+        const apiResponse = await API.get('files', `/s3?${queryString}`, {});
+        await getPresignedUrlForEveryItem(apiResponse);
+        if (componentUnmount) return;
+        setApiResults((prev) => ({
+          nextPageLink: apiResponse.links.next,
+          items: [...prev.items, ...apiResponse.results],
+          isLoading: false,
+          isError: false,
+        }));
+      } catch {
+        if (componentUnmount) return;
+        setApiResults((prev) => ({
+          ...prev,
+          isLoading: false,
+          isError: true,
+        }));
+      }
+    };
+    if (queryNextUrlString != null && queryNextUrlString !== '') {
+      fetchData(queryNextUrlString);
+    }
+
+    return () => {
+      componentUnmount = true;
+    };
+  }, [queryNextUrlString]);
+
+  return (
+    <Paper
+      elevation={3}
+      style={{
+        flexDirection: 'column',
+        display: 'flex',
+        width: '100%',
+        minHeight: '600px',
+        height: 'calc(100vh - 96px)', // 96px is magic number from toolbar and padding
+      }}>
+      <Grid
+        container
+        direction='column'
+        justifyContent='flex-start'
+        alignItems='stretch'
+        wrap='nowrap'
+        style={{ padding: '1rem', height: '100%' }}>
+        {/* Title - First Row */}
+        <Grid item container direction='row' justifyContent='flex-start' alignItems='center'>
+          <Grid item>
+            <IconButton component={Link} to={`/subjects/${subjectId}`}>
+              <ChevronLeft />
+            </IconButton>
+          </Grid>
+          <Grid item>
+            <Typography variant='h6'>
+              {subjectId} - Image Analysis Output: {pipelineSelection.name}
+            </Typography>
+          </Grid>
+        </Grid>
+
+        {/* INPUT - Second Row */}
+        <Grid
+          item
+          style={{ padding: '1rem', width: '100%' }}
+          container
+          direction='row'
+          justifyContent='flex-start'
+          alignItems='center'>
+          <FormControl style={{ width: '100%' }}>
+            <InputLabel id='select-workflow'>Pipeline Report</InputLabel>
+            <Select
+              labelId='demo-simple-select-label'
+              id='demo-simple-select'
+              value={JSON.stringify(pipelineSelection)}
+              onChange={handleSelectionChange}>
+              {PIPELINE_OPTIONS_LIST.map((item, index) => {
+                return (
+                  <MenuItem key={index} value={JSON.stringify(item)}>
+                    {item.name}
+                  </MenuItem>
+                );
+              })}
+            </Select>
+          </FormControl>
+        </Grid>
+
+        {/* List & Preview */}
+        <Grid
+          item
+          style={{
+            width: '100%',
+            height: 'calc(100% - 137px)',
+            padding: '1rem',
+          }}
+          container
+          direction='row'
+          justifyContent='center'
+          alignItems='center'>
+          {apiResults.isLoading ? (
+            <CircularProgress />
+          ) : apiResults.isError ? (
+            <Grid container direction='column' justifyContent='center' alignItems='center'>
+              <WarningIcon />
+              <Typography>Something went wrong!</Typography>
+            </Grid>
+          ) : apiResults.items.length == 0 ? (
+            <Grid container direction='column' justifyContent='center' alignItems='center'>
+              <WarningIcon />
+              <Typography>No Data</Typography>
+            </Grid>
+          ) : (
+            <Grid
+              container
+              direction='row'
+              justifyContent='flex-start'
+              alignItems='stretch'
+              style={{ height: '100%' }}>
+              <Grid item xs={4} style={{ overflow: 'auto', height: '100%' }}>
+                <Grid container direction='column'>
+                  {apiResults.items.map((item, index) => {
+                    let filename = item.key.split('/').pop();
+                    const isSelected = selectedPreview && selectedPreview.id === item.id;
+                    return (
+                      <Grid item key={index} style={{ padding: '0' }}>
+                        <ButtonBase
+                          style={{
+                            width: '100%',
+                            height: '100%',
+                            justifyContent: 'flex-start',
+                            backgroundColor: isSelected ? grey[300] : '',
+                            padding: '0.5rem',
+                          }}
+                          onClick={() => setSelectedPreview(item)}>
+                          <Typography noWrap variant='body2'>
+                            {filename}
+                          </Typography>
+                        </ButtonBase>
+                      </Grid>
+                    );
+                  })}
+                  {apiResults.nextPageLink == null ? (
+                    <></>
+                  ) : (
+                    <Grid item style={{ padding: '0' }}>
+                      <ButtonBase
+                        style={{
+                          width: '100%',
+                          height: '100%',
+                          justifyContent: 'center',
+                          backgroundColor: grey[100],
+                          padding: '0.5rem',
+                        }}
+                        onClick={() => setQueryNextUrlString(apiResults.nextPageLink)}>
+                        Load More
+                      </ButtonBase>
+                    </Grid>
+                  )}
+                </Grid>
+              </Grid>
+              <Grid
+                item
+                xs={8}
+                style={{
+                  borderLeft: `1pt solid ${grey[300]}`,
+                  height: '100%',
+                  display: 'flex',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                }}>
+                {selectedPreview == null ? (
+                  <CircularProgress />
+                ) : (
+                  <img
+                    style={{ maxHeight: '100%', maxWidth: '100%', backgroundColor: 'white' }}
+                    onClick={() => window.open(selectedPreview.presignedUrl, '_blank')}
+                    src={selectedPreview.presignedUrl}
+                  />
+                )}
+              </Grid>
+            </Grid>
+          )}
+        </Grid>
+      </Grid>
+    </Paper>
+  );
+}
+
+async function getPresignedUrlForEveryItem(apiResponse: any) {
+  for (const item of apiResponse.results) {
+    const id = item.id;
+    const presignedUrl = await getPreSignedUrl(id);
+    item['presignedUrl'] = presignedUrl;
+  }
+}
+
+async function getPreSignedUrl(id: string) {
+  const { error, signed_url } = await API.get('files', `/s3/${id}/presign`, {});
+
+  if (error) {
+    throw Error('Unable to fetch get presigned url.');
+  }
+  return signed_url;
+}
+
+export default FileViewers;

--- a/src/containers/FileViewers.tsx
+++ b/src/containers/FileViewers.tsx
@@ -14,7 +14,7 @@ import {
   Select,
   ImageListItemBar,
 } from '@material-ui/core';
-import { grey } from '@material-ui/core/colors';
+import { blueGrey, grey } from '@material-ui/core/colors';
 
 // MUI - Icons
 import ChevronLeft from '@material-ui/icons/ChevronLeft';
@@ -98,7 +98,7 @@ function FileViewers() {
         queryStringParameters: {
           subject: `${subjectId}`,
           search: pipelineSelection.regexKey,
-          rowsPerPage: 10,
+          rowsPerPage: 25,
           ordering: 'key',
         },
       };
@@ -255,8 +255,26 @@ function FileViewers() {
               justifyContent='flex-start'
               alignItems='stretch'
               style={{ height: '100%' }}>
-              <Grid item xs={4} style={{ overflow: 'auto', height: '100%' }}>
-                <Grid container direction='column'>
+              <Grid item xs={4} style={{ overflow: 'auto', height: '100%', position: 'relative' }}>
+                <Grid container direction='column' style={{}}>
+                  <Grid
+                    item
+                    container
+                    alignItems='center'
+                    style={{
+                      padding: '0',
+                      minHeight: '48px',
+                      backgroundColor: blueGrey[50],
+                      position: 'sticky',
+                      zIndex: '1',
+                      top: 0,
+                      borderBottom: 'solid 1px black',
+                      paddingLeft: '1rem',
+                    }}>
+                    <Typography variant='h6' style={{}}>
+                      Filename
+                    </Typography>
+                  </Grid>
                   {apiResults.items.map((item, index) => {
                     let filename = item.key.split('/').pop();
                     const isSelected = selectedPreview && selectedPreview.id === item.id;

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -25,6 +25,7 @@ import LimsRowDetailsDialog from '../components/LimsRowDetailsDialog';
 import { Link as RouterLink } from 'react-router-dom';
 import InfoIcon from '@material-ui/icons/Info';
 import Link from '@material-ui/core/Link';
+import ImageIcon from '@material-ui/icons/Image';
 
 const styles = (theme) => ({
   close: {
@@ -122,6 +123,7 @@ class Home extends Component {
     const { dialogOpened, rowData } = this.state;
     const columns = [
       { key: 'info', sortable: false },
+      { key: 'files_viewer', sortable: false },
       { key: 'illumina_id', sortable: true },
       { key: 'type', sortable: true },
       { key: 'timestamp', sortable: true },
@@ -201,6 +203,15 @@ class Home extends Component {
                             {row[col.key]}
                           </Link>
                         )}
+                      </TableCell>
+                    ) : col.key === 'files_viewer' ? (
+                      <TableCell key={col.key}>
+                        <IconButton
+                          component={RouterLink}
+                          aria-label='files_viewer'
+                          to={`/files/${row.subject_id}`}>
+                          <ImageIcon color={'action'} />
+                        </IconButton>
                       </TableCell>
                     ) : (
                       <TableCell key={col.key}>{row[col.key]}</TableCell>

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -123,7 +123,7 @@ class Home extends Component {
     const { dialogOpened, rowData } = this.state;
     const columns = [
       { key: 'info', sortable: false },
-      { key: 'files_viewer', sortable: false },
+      { key: 'file_viewer', sortable: false },
       { key: 'illumina_id', sortable: true },
       { key: 'type', sortable: true },
       { key: 'timestamp', sortable: true },
@@ -204,11 +204,11 @@ class Home extends Component {
                           </Link>
                         )}
                       </TableCell>
-                    ) : col.key === 'files_viewer' ? (
+                    ) : col.key === 'file_viewer' ? (
                       <TableCell key={col.key}>
                         <IconButton
                           component={RouterLink}
-                          aria-label='files_viewer'
+                          aria-label='file_viewer'
                           to={`/files/${row.subject_id}`}>
                           <ImageIcon color={'action'} />
                         </IconButton>

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -25,7 +25,7 @@ import LimsRowDetailsDialog from '../components/LimsRowDetailsDialog';
 import { Link as RouterLink } from 'react-router-dom';
 import InfoIcon from '@material-ui/icons/Info';
 import Link from '@material-ui/core/Link';
-import ImageIcon from '@material-ui/icons/Image';
+import ImageSearchIcon from '@material-ui/icons/ImageSearch';
 
 const styles = (theme) => ({
   close: {
@@ -207,10 +207,11 @@ class Home extends Component {
                     ) : col.key === 'file_viewer' ? (
                       <TableCell key={col.key}>
                         <IconButton
+                          disabled={row.subject_id ? false : true}
                           component={RouterLink}
                           aria-label='file_viewer'
                           to={`/files/${row.subject_id}`}>
-                          <ImageIcon color={'action'} />
+                          <ImageSearchIcon color={row.subject_id ? 'action' : 'disabled'} />
                         </IconButton>
                       </TableCell>
                     ) : (

--- a/src/containers/Subject.js
+++ b/src/containers/Subject.js
@@ -57,6 +57,7 @@ import List from '@material-ui/core/List';
 import MenuBookIcon from '@material-ui/icons/MenuBook';
 import LaunchPadDialog from '../components/LaunchPadDialog';
 import PreviewActionButton from '../components/PreviewActionButton';
+import PhotoLibraryIcon from '@material-ui/icons/PhotoLibrary';
 
 const styles = (theme) => ({
   close: {
@@ -680,6 +681,12 @@ class Subject extends Component {
               <MenuBookIcon color={'primary'} />
             </ListItemIcon>
             <ListItemText primary={'Generate GRIDSS PURPLE LINX Report'} />
+          </ListItem>
+          <ListItem button component={RouterLink} to={'/files/' + subjectId}>
+            <ListItemIcon>
+              <PhotoLibraryIcon color={'action'} />
+            </ListItemIcon>
+            <ListItemText primary='View Analysis Output Images' />
           </ListItem>
         </List>
         <LaunchPadDialog


### PR DESCRIPTION
- Added new route `/files/{subjectId}` for png preview files from S3
- Available preview options (with RegExr): 
```
  { name: 'GPL - all', regexKey: 'gridss_purple_linx/(.*)(.png$)' },
  { name: 'GPL - purple', regexKey: 'gridss_purple_linx/purple/(.*)(.png$)' },
  { name: 'GPL - linx', regexKey: 'gridss_purple_linx/linx/(.*)(.png$)' },
  { name: 'UMCCRISED - all', regexKey: 'umccrised/(.*)(.png$)' },
```
- Added button to link to this routes via `lims-table` and `subject-page`