### PR TITLE
patch issue #166 - Open IGV Desktop

### DIFF
--- a/src/components/DataActionButton/index.tsx
+++ b/src/components/DataActionButton/index.tsx
@@ -194,6 +194,8 @@ function OpenIGVDesktop(props: OpenIGVDesktopType) {
       detail: `${s3LocalIgvUrl.error}`,
       sticky: true,
     });
+    handleIsOpen(false);
+    return <></>;
   }
   if (gdsLocalIgvUrl.isError && gdsLocalIgvUrl.error) {
     toast?.show({
@@ -202,6 +204,8 @@ function OpenIGVDesktop(props: OpenIGVDesktopType) {
       detail: `${gdsLocalIgvUrl.error}`,
       sticky: true,
     });
+    handleIsOpen(false);
+    return <></>;
   }
 
   const xhr = new XMLHttpRequest();


### PR DESCRIPTION
Essentially, the `OpenIGVDesktop` component/button must also return the component and close the dialog (to enable retries).