### PR TITLE
Bug Fixes: Date && Cache

### DIFF
--- a/src/api/gds.ts
+++ b/src/api/gds.ts
@@ -11,7 +11,24 @@ export type GDSRow = {
   time_modified: string;
   size_in_bytes: number;
   volume_name: string;
-} & Record<string, string | number | boolean | null>;
+  file_id: string;
+  name: string;
+  volume_id: string;
+  type: string;
+  tenant_id: string;
+  sub_tenant_id: string;
+  time_created: string;
+  created_by: string;
+  modified_by: string;
+  inherited_acl: string;
+  urn: string;
+  is_uploaded: true;
+  archive_status: string;
+  time_archived: string | null;
+  storage_tier: string;
+  presigned_url: string | null;
+  unique_hash: string;
+};
 
 export function usePortalGDSAPI(apiConfig: Record<string, any>) {
   return useQuery(

--- a/src/api/gds.ts
+++ b/src/api/gds.ts
@@ -14,15 +14,15 @@ export type GDSRow = {
   file_id: string;
   name: string;
   volume_id: string;
-  type: string;
+  type: string | null;
   tenant_id: string;
   sub_tenant_id: string;
   time_created: string;
   created_by: string;
   modified_by: string;
-  inherited_acl: string;
+  inherited_acl: string | null;
   urn: string;
-  is_uploaded: true;
+  is_uploaded: true | null;
   archive_status: string;
   time_archived: string | null;
   storage_tier: string;

--- a/src/api/s3.ts
+++ b/src/api/s3.ts
@@ -13,7 +13,7 @@ export type S3Row = {
   last_modified_date: string;
   e_tag: string;
   unique_hash: string;
-} & Record<string, string>;
+};
 
 export type S3ApiData = DjangoRestApiResponse & { results: S3Row[] };
 

--- a/src/components/DataActionButton/index.tsx
+++ b/src/components/DataActionButton/index.tsx
@@ -282,19 +282,25 @@ function PresignedUrlDialog(props: PresignedUrlDialogProps) {
   const { toastShow } = useToastContext();
 
   const { id, type, handleIsOpen } = props;
-  const { isLoading, isError, data } = useQuery('fetchDataPresignedUrl', () => {
-    if (type == 's3') {
-      return getS3PreSignedUrl(id);
-    } else {
-      return getGDSPreSignedUrl(id);
-    }
+  const { isLoading, isError, data } = useQuery({
+    queryKey: ['fetchDataPresignedUrl', id, type],
+    keepPreviousData: false,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
+    queryFn: async () => {
+      if (type == 's3') {
+        return await getS3PreSignedUrl(id);
+      } else {
+        return await getGDSPreSignedUrl(id);
+      }
+    },
   });
 
   let expiresIn = '';
   if (data) {
     const queryParam = parseUrlParams(data);
     if (type == 's3') {
-      expiresIn = moment.unix(parseInt(queryParam['Expires'])).local().toString();
+      expiresIn = moment.unix(parseInt(queryParam['Expires'])).toString();
     } else {
       expiresIn = moment().add(parseInt(queryParam['X-Amz-Expires']), 's').toString();
     }

--- a/src/components/DataActionButton/index.tsx
+++ b/src/components/DataActionButton/index.tsx
@@ -293,7 +293,11 @@ function PresignedUrlDialog(props: PresignedUrlDialogProps) {
   let expiresIn = '';
   if (data) {
     const queryParam = parseUrlParams(data);
-    expiresIn = queryParam['Expires'];
+    if (type == 's3') {
+      expiresIn = queryParam['Expires'];
+    } else {
+      expiresIn = queryParam['X-Amz-Expires'];
+    }
   }
 
   return (

--- a/src/components/DataActionButton/index.tsx
+++ b/src/components/DataActionButton/index.tsx
@@ -294,9 +294,9 @@ function PresignedUrlDialog(props: PresignedUrlDialogProps) {
   if (data) {
     const queryParam = parseUrlParams(data);
     if (type == 's3') {
-      expiresIn = queryParam['Expires'];
+      expiresIn = moment.unix(parseInt(queryParam['Expires'])).local().toString();
     } else {
-      expiresIn = queryParam['X-Amz-Expires'];
+      expiresIn = moment().add(parseInt(queryParam['X-Amz-Expires']), 's').toString();
     }
   }
 
@@ -318,7 +318,7 @@ function PresignedUrlDialog(props: PresignedUrlDialogProps) {
             value={[
               {
                 key: 'Expires in',
-                value: moment.unix(parseInt(expiresIn)).local().format('LLLL'),
+                value: expiresIn,
               },
               { key: 'URL', value: data },
             ]}

--- a/src/containers/gds/GDSDataTable/index.tsx
+++ b/src/containers/gds/GDSDataTable/index.tsx
@@ -90,19 +90,19 @@ export default GDSDataTable;
 const textBodyTemplate = (text: string | number | boolean | null): React.ReactNode => {
   return <div>{text?.toString()}</div>;
 };
-const column_to_display: string[] = [
+const column_to_display = [
   'volume_name',
   'path',
   'preview',
   'action',
   'size_in_bytes',
   'time_modified',
-];
+] as const;
 const columnList: ColumnProps[] = [];
 
 // Creating column properties based on field to display
 for (const column of column_to_display) {
-  let newColToShow = {
+  const defaultProps = {
     field: column,
     alignHeader: 'left' as const,
     header: (
@@ -110,24 +110,20 @@ for (const column of column_to_display) {
         {showDisplayText(column)}
       </p>
     ),
-    body: (rowData: GDSRow): React.ReactNode => {
-      return textBodyTemplate(rowData[column]);
-    },
     className: 'text-left white-space-nowrap',
   };
 
   if (column == 'preview') {
-    newColToShow = {
-      ...newColToShow,
+    columnList.push({
+      ...defaultProps,
       header: (
         <p className='w-2 capitalize text-left font-bold text-color white-space-nowrap overflow-visible'>
           {showDisplayText(column)}
         </p>
       ),
       className: 'text-center white-space-nowrap overflow-visible',
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      body: (rowData: any): React.ReactNode => {
-        const filename = rowData.path.split('/').pop();
+      body: (rowData: GDSRow): React.ReactNode => {
+        const filename = rowData.path.split('/').pop() ?? rowData.path;
         const fileSizeInBytes = rowData.size_in_bytes;
         return (
           <FilePreviewButton
@@ -138,10 +134,10 @@ for (const column of column_to_display) {
           />
         );
       },
-    };
+    });
   } else if (column == 'action') {
-    newColToShow = {
-      ...newColToShow,
+    columnList.push({
+      ...defaultProps,
       body: (rowData: GDSRow): React.ReactNode => {
         return (
           <DataActionButton
@@ -153,10 +149,10 @@ for (const column of column_to_display) {
         );
       },
       className: 'text-center white-space-nowrap overflow-visible',
-    };
+    });
   } else if (column == 'size_in_bytes') {
-    newColToShow = {
-      ...newColToShow,
+    columnList.push({
+      ...defaultProps,
       body: (rowData: GDSRow): React.ReactNode => {
         let sizeNumber = 0;
         if (typeof rowData.size_in_bytes == 'string') {
@@ -166,15 +162,20 @@ for (const column of column_to_display) {
         }
         return textBodyTemplate(getStringReadableBytes(sizeNumber));
       },
-    };
+    });
   } else if (column == 'time_modified') {
-    newColToShow = {
-      ...newColToShow,
+    columnList.push({
+      ...defaultProps,
       body: (rowData: GDSRow): React.ReactNode => {
         return textBodyTemplate(moment(rowData.time_modified).local().format('LLL'));
       },
-    };
+    });
+  } else {
+    columnList.push({
+      ...defaultProps,
+      body: (rowData: GDSRow): React.ReactNode => {
+        return textBodyTemplate(rowData[column]);
+      },
+    });
   }
-
-  columnList.push(newColToShow);
 }

--- a/src/containers/gds/GDSDataTable/index.tsx
+++ b/src/containers/gds/GDSDataTable/index.tsx
@@ -167,7 +167,7 @@ for (const column of column_to_display) {
     columnList.push({
       ...defaultProps,
       body: (rowData: GDSRow): React.ReactNode => {
-        return textBodyTemplate(moment(rowData.time_modified).local().format('LLL'));
+        return textBodyTemplate(moment(rowData.time_modified).toString());
       },
     });
   } else {

--- a/src/containers/s3/S3DataTable/index.tsx
+++ b/src/containers/s3/S3DataTable/index.tsx
@@ -92,20 +92,19 @@ export default S3DataTable;
 const textBodyTemplate = (text: string | number | boolean | null): React.ReactNode => {
   return <div>{text?.toString()}</div>;
 };
-const column_to_display: string[] = [
+const column_to_display = [
   'bucket',
   'key',
   'preview',
   'action',
   'size',
   'last_modified_date',
-];
+] as const;
 const columnList: ColumnProps[] = [];
 
 // Creating column properties based on field to display
 for (const column of column_to_display) {
-  // Column template
-  let newColToShow = {
+  const defaultProps = {
     field: column,
     alignHeader: 'left' as const,
     header: (
@@ -113,16 +112,14 @@ for (const column of column_to_display) {
         {showDisplayText(column)}
       </p>
     ),
-    body: (rowData: S3Row): React.ReactNode => {
-      return textBodyTemplate(rowData[column]);
-    },
+
     className: 'text-left white-space-nowrap',
   };
 
   // Customize column from the template column above
   if (column == 'preview') {
-    newColToShow = {
-      ...newColToShow,
+    columnList.push({
+      ...defaultProps,
       className: 'text-center white-space-nowrap overflow-visible',
       body: (rowData: S3Row): React.ReactNode => {
         const filename = rowData.key.split('/').pop() ?? rowData.key;
@@ -136,10 +133,10 @@ for (const column of column_to_display) {
           />
         );
       },
-    };
+    });
   } else if (column == 'action') {
-    newColToShow = {
-      ...newColToShow,
+    columnList.push({
+      ...defaultProps,
       body: (rowData: S3Row): React.ReactNode => {
         return (
           <DataActionButton
@@ -151,10 +148,10 @@ for (const column of column_to_display) {
         );
       },
       className: 'text-center white-space-nowrap',
-    };
+    });
   } else if (column == 'size') {
-    newColToShow = {
-      ...newColToShow,
+    columnList.push({
+      ...defaultProps,
       body: (rowData: S3Row): React.ReactNode => {
         let sizeNumber = 0;
         if (typeof rowData.size == 'string') {
@@ -164,15 +161,20 @@ for (const column of column_to_display) {
         }
         return textBodyTemplate(getStringReadableBytes(sizeNumber));
       },
-    };
+    });
   } else if (column == 'last_modified_date') {
-    newColToShow = {
-      ...newColToShow,
+    columnList.push({
+      ...defaultProps,
       body: (rowData: S3Row): React.ReactNode => {
         return textBodyTemplate(moment(rowData.last_modified_date).local().format('LLL'));
       },
-    };
+    });
+  } else {
+    columnList.push({
+      ...defaultProps,
+      body: (rowData: S3Row): React.ReactNode => {
+        return textBodyTemplate(rowData[column]);
+      },
+    });
   }
-
-  columnList.push(newColToShow);
 }

--- a/src/containers/s3/S3DataTable/index.tsx
+++ b/src/containers/s3/S3DataTable/index.tsx
@@ -166,7 +166,7 @@ for (const column of column_to_display) {
     columnList.push({
       ...defaultProps,
       body: (rowData: S3Row): React.ReactNode => {
-        return textBodyTemplate(moment(rowData.last_modified_date).local().format('LLL'));
+        return textBodyTemplate(moment(rowData.last_modified_date).toString());
       },
     });
   } else {

--- a/src/containers/subjects/AnalysisResultTable/index.tsx
+++ b/src/containers/subjects/AnalysisResultTable/index.tsx
@@ -25,6 +25,11 @@ const filenameTemplate = (rowData: Record<string, any>) => {
   return <div className='white-space-nowrap'>{filename}</div>;
 };
 
+/**
+ * The following some template to view column data.
+ * Note that the variable naming might be specific to S3 or GDS.
+ */
+
 const actionGDSTemplate = (rowData: GDSRow) => {
   return (
     <DataActionButton
@@ -46,15 +51,8 @@ const actionS3Template = (rowData: S3Row) => {
     />
   );
 };
-const fileSizeGDSTemplate = (rowData: Record<string, any>) => {
-  const readableSize = getStringReadableBytes(rowData.size_in_bytes);
-  return (
-    <div className='white-space-nowrap overflow-visible' style={{ width: '75px' }}>
-      {readableSize}
-    </div>
-  );
-};
-const fileSizeS3Template = (rowData: Record<string, any>) => {
+
+const fileSizeS3Template = (rowData: S3Row) => {
   const readableSize = getStringReadableBytes(rowData.size);
   return (
     <div className='white-space-nowrap overflow-visible' style={{ width: '75px' }}>
@@ -62,7 +60,17 @@ const fileSizeS3Template = (rowData: Record<string, any>) => {
     </div>
   );
 };
-const timeModifiedTemplate = (rowData: Record<string, any>) => {
+
+const fileSizeGDSTemplate = (rowData: GDSRow) => {
+  const readableSize = getStringReadableBytes(rowData.size_in_bytes);
+  return (
+    <div className='white-space-nowrap overflow-visible' style={{ width: '75px' }}>
+      {readableSize}
+    </div>
+  );
+};
+
+const timeModifiedS3Template = (rowData: S3Row) => {
   const readableTimeStamp = moment(rowData.last_modified_date).local().format('LLL');
   return (
     <div className='white-space-nowrap' style={{ width: '180px' }}>
@@ -71,24 +79,17 @@ const timeModifiedTemplate = (rowData: Record<string, any>) => {
   );
 };
 
-const previewGDSTemplate = (rowData: Record<string, any>) => {
-  const filename = rowData.path.split('/').pop();
-  const fileSizeInBytes = rowData.size_in_bytes;
-
+const timeModifiedGDSTemplate = (rowData: GDSRow) => {
   return (
-    <div style={{ width: '15px' }}>
-      <FilePreviewButton
-        id={rowData.id}
-        filename={filename}
-        fileSizeInBytes={fileSizeInBytes}
-        type='gds'
-      />
+    <div className='white-space-nowrap' style={{ width: '180px' }}>
+      {moment(rowData.time_modified).local().format('LLL')}
+      {/* <Moment local>{rowData.time_modified}</Moment> */}
     </div>
   );
 };
 
-const previewS3Template = (rowData: Record<string, any>) => {
-  const filename = rowData.key.split('/').pop();
+const previewS3Template = (rowData: S3Row) => {
+  const filename = rowData.key.split('/').pop() ?? rowData.key;
   const fileSizeInBytes = rowData.size;
 
   return (
@@ -98,6 +99,22 @@ const previewS3Template = (rowData: Record<string, any>) => {
         id={rowData.id}
         filename={filename}
         type='s3'
+      />
+    </div>
+  );
+};
+
+const previewGDSTemplate = (rowData: GDSRow) => {
+  const filename = rowData.path.split('/').pop() ?? rowData.path;
+  const fileSizeInBytes = rowData.size_in_bytes;
+
+  return (
+    <div style={{ width: '15px' }}>
+      <FilePreviewButton
+        id={rowData.id}
+        filename={filename}
+        fileSizeInBytes={fileSizeInBytes}
+        type='gds'
       />
     </div>
   );
@@ -117,7 +134,7 @@ function AnalysisResultGDSTable(prop: AnalysisResultGDSTableProps) {
         <Column body={previewGDSTemplate} headerStyle={{ display: 'none' }} />
         <Column body={actionGDSTemplate} headerStyle={{ display: 'none' }} />
         <Column body={fileSizeGDSTemplate} headerStyle={{ display: 'none' }} />
-        <Column body={timeModifiedTemplate} headerStyle={{ display: 'none' }} />
+        <Column body={timeModifiedGDSTemplate} headerStyle={{ display: 'none' }} />
       </DataTable>
     </div>
   );
@@ -138,7 +155,7 @@ function AnalysisResultS3Table(prop: AnalysisResultGDSTableProps) {
         <Column body={previewS3Template} headerStyle={{ display: 'none' }} />
         <Column body={actionS3Template} headerStyle={{ display: 'none' }} />
         <Column body={fileSizeS3Template} headerStyle={{ display: 'none' }} />
-        <Column body={timeModifiedTemplate} headerStyle={{ display: 'none' }} />
+        <Column body={timeModifiedS3Template} headerStyle={{ display: 'none' }} />
       </DataTable>
     </div>
   );

--- a/src/containers/subjects/AnalysisResultTable/index.tsx
+++ b/src/containers/subjects/AnalysisResultTable/index.tsx
@@ -71,9 +71,9 @@ const fileSizeGDSTemplate = (rowData: GDSRow) => {
 };
 
 const timeModifiedS3Template = (rowData: S3Row) => {
-  const readableTimeStamp = moment(rowData.last_modified_date).local().format('LLL');
+  const readableTimeStamp = moment(rowData.last_modified_date).toString();
   return (
-    <div className='white-space-nowrap' style={{ width: '180px' }}>
+    <div className='white-space-nowrap' style={{ width: '250px' }}>
       {readableTimeStamp}
     </div>
   );
@@ -81,9 +81,8 @@ const timeModifiedS3Template = (rowData: S3Row) => {
 
 const timeModifiedGDSTemplate = (rowData: GDSRow) => {
   return (
-    <div className='white-space-nowrap' style={{ width: '180px' }}>
-      {moment(rowData.time_modified).local().format('LLL')}
-      {/* <Moment local>{rowData.time_modified}</Moment> */}
+    <div className='white-space-nowrap' style={{ width: '250px' }}>
+      {moment(rowData.time_modified).toString()}
     </div>
   );
 };

--- a/src/containers/utils/TokenDialog/index.tsx
+++ b/src/containers/utils/TokenDialog/index.tsx
@@ -109,7 +109,7 @@ function TokenDialog(props: Props) {
               value={[
                 {
                   key: 'Expires in',
-                  value: moment.unix(parseInt(JWTData.expires)).local().format('LLLL'),
+                  value: moment.unix(parseInt(JWTData.expires)).toString(),
                 },
                 { key: 'JWT', value: JWTData.token },
               ]}


### PR DESCRIPTION
- Identify and Fix on Date parsing Bug
	
	Problem: GDS uses `time_modified` while S3 uses `last_modified_date`, previous attempt did not distinguish between this fields and uses the same key which causes the bug for undefined and led to date to show current date.
	
	Solution: Having a seperate function/component to view GDS and S3 date from API response. Additionally all typed Backend response are also added to respective GDS/S3 Rows.

- Added more dependancy for presignedUrl fetching 
	
	Problem: Fetching dependancy did not rely on objectId as it rely to refetch as component is remounting when navigate to preosignedUrl component. This might hit edge case when user had been idle too long but data still exist from previous data.
	
	Solution: Added S3/GDS ID and the type for dependancy when fetching presignUrl. This should resolve caching issue that return previous data. Also added more options to refresh on every mount and window focus. 
	
- PresignUrl Invalid Date
	
	Problem: presign url in  GDS uses `X-Amz-Expires` while S3 uses `Expires` in the query params.
	
	Solution: Handle the date parsing from url query params accordingly to show in UI.




Fix #197 
Fix #198 