### PR TITLE
Allowed RNAsum trigger on multiple transcriptome output

### DIFF
--- a/src/containers/subjects/SubjectRNASumLaunch/index.tsx
+++ b/src/containers/subjects/SubjectRNASumLaunch/index.tsx
@@ -259,12 +259,6 @@ function checkRnasumTriggerAllow(gdsResult: GDSRow[]): RNASumLaunchCheckType {
     return rnasumCheck;
   }
 
-  if (rnasumInputData.wtsBamsIca.length > 1) {
-    rnasumCheck.isRNASumLaunchAllowed = false;
-    rnasumCheck.message = `Multiple transcriptome workflow output found for the Subject.`;
-    return rnasumCheck;
-  }
-
   if (rnasumInputData.wgsCancer.length < 1) {
     rnasumCheck.isRNASumLaunchAllowed = false;
     rnasumCheck.message = `No umccrise workflow output found for the Subject.`;


### PR DESCRIPTION
* Pipeline automation will use "latest greatest" strategy
  i.e. it uses "recent" WTS library and its most recent
  transcriptome run output automatically
* Related #219
  https://github.com/umccr/data-portal-apis/issues/547
