### PR TITLE
Implemented open Report in inline browser tab

### DIFF
--- a/src/api/gds.ts
+++ b/src/api/gds.ts
@@ -65,7 +65,7 @@ export function usePortalGDSPresignAPI(gdsId?: string | number, apiConfig?: Reco
 export async function getGDSPreSignedUrl(id: number, apiConfig?: Record<string, any>) {
   const { error, signed_url } = await API.get('portal', `/gds/${id}/presign`, { ...apiConfig });
   if (error) {
-    throw Error('Unable to fetch get presigned url.');
+    throw Error('Unable to get PreSigned URL');
   }
   return signed_url;
 }

--- a/src/api/s3.ts
+++ b/src/api/s3.ts
@@ -101,7 +101,7 @@ export function usePortalS3StatusAPI(s3Id?: string | number) {
 export async function getS3PreSignedUrl(id: number) {
   const { error, signed_url } = await API.get('portal', `/s3/${id}/presign`, {});
   if (error) {
-    throw Error('Unable to fetch get presigned url.');
+    throw Error('Unable to get PreSigned URL');
   }
   return signed_url;
 }

--- a/src/providers/ToastProvider/index.tsx
+++ b/src/providers/ToastProvider/index.tsx
@@ -17,12 +17,7 @@ function ToastProvider(props: Props) {
   const toastShow = useCallback((m: ToastMessageType) => toastRef.current?.show(m), []);
   return (
     <>
-      <Toast
-        ref={toastRef}
-        position='top-center'
-        className='opacity-100 w-6'
-        style={{ maxWidth: '1000px' }}
-      />
+      <Toast ref={toastRef} position='bottom-left' className='w-6' style={{ maxWidth: '1000px' }} />
       <ToastContext.Provider value={{ toastShow: toastShow }}>
         {props.children}
       </ToastContext.Provider>


### PR DESCRIPTION
* Going ford UI/UX: Opening a html Report in new inline browser tab
  shall be our default option
* Everything else is secondary options such as download, preview, ...
* Adjusted Toast message to screen Left Bottom position, no opacity and,
  this should be default message location. As that corner will be
  our best less crowded screen estate.
* Resolves #162
