### PR TITLE
Fixed Generate Download Link

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@aws-amplify/core": "^5.1.5",
     "@aws-sdk/client-lambda": "^3.300.0",
     "igv": "2.13.11",
+    "mime": "^3.0.0",
     "moment": "^2.29.4",
     "primeflex": "^3.3.0",
     "primeicons": "^6.0.1",
@@ -32,6 +33,7 @@
     "unsplash-js": "^7.0.15"
   },
   "devDependencies": {
+    "@types/mime": "^3.0.1",
     "@types/node": "^18.15.10",
     "@types/react": "^18.0.30",
     "@types/react-dom": "^18.0.11",

--- a/src/components/FilePreviewButton/index.tsx
+++ b/src/components/FilePreviewButton/index.tsx
@@ -5,6 +5,7 @@ import ViewPresignedUrl, {
   DATA_TYPE_SUPPORTED,
   HTML_FILETYPE_LIST,
   IMAGE_FILETYPE_LIST,
+  isRequestInlineContentDisposition,
 } from '../ViewPresignedUrl';
 import { usePortalGDSPresignAPI } from '../../api/gds';
 import { usePortalS3PresignAPI } from '../../api/s3';
@@ -78,12 +79,16 @@ type FilePreviewDialogProps = FilePreviewButtonProps & {
 };
 function FilePreviewDialog(props: FilePreviewDialogProps) {
   const { filename, id, type, handleDialogClose } = props;
+  const split_path = filename.split('.');
+  const filetype = split_path[split_path.length - 1].toLowerCase();
 
   let portalPresignedUrlRes;
   if (type == 'gds') {
     portalPresignedUrlRes = usePortalGDSPresignAPI(id, {
       headers: {
-        'Content-Disposition': 'inline',
+        'Content-Disposition': isRequestInlineContentDisposition(filetype)
+          ? 'inline'
+          : 'attachment',
         'Content-Type': mime.getType(filename),
       },
     });

--- a/src/components/FilePreviewButton/index.tsx
+++ b/src/components/FilePreviewButton/index.tsx
@@ -8,6 +8,7 @@ import ViewPresignedUrl, {
 } from '../ViewPresignedUrl';
 import { usePortalGDSPresignAPI } from '../../api/gds';
 import { usePortalS3PresignAPI } from '../../api/s3';
+import mime from 'mime';
 
 type FilePreviewButtonProps = {
   filename: string;
@@ -81,7 +82,10 @@ function FilePreviewDialog(props: FilePreviewDialogProps) {
   let portalPresignedUrlRes;
   if (type == 'gds') {
     portalPresignedUrlRes = usePortalGDSPresignAPI(id, {
-      headers: { 'Content-Disposition': 'inline' },
+      headers: {
+        'Content-Disposition': 'inline',
+        'Content-Type': mime.getType(filename),
+      },
     });
   } else {
     portalPresignedUrlRes = usePortalS3PresignAPI(id);

--- a/src/components/GeneratePresignedDialog/index.tsx
+++ b/src/components/GeneratePresignedDialog/index.tsx
@@ -33,7 +33,7 @@ export default function GeneratePresignedDialog(props: GeneratePresignedDialogPr
       if (type == 's3') {
         return await getS3PreSignedUrl(id);
       } else {
-        return await getGDSPreSignedUrl(id, { headers: { 'Content-Disposition': 'inline' } });
+        return await getGDSPreSignedUrl(id);
       }
     },
   });

--- a/src/components/ViewPresignedUrl/index.tsx
+++ b/src/components/ViewPresignedUrl/index.tsx
@@ -233,3 +233,17 @@ export default function ViewPresignedUrl({ presingedUrl }: Props) {
 
   return <div>Cannot display file</div>;
 }
+
+/**
+ * HELPER FUNCTION
+ */
+
+/**
+ * This would be useful to determine whether the requested URL need to be `inline` or `attachment` content disposition.
+ * HTML and Image by default will need to be inline as the behaviour desired is to open in browser/iframe without download.
+ * @param filetype
+ * @returns
+ */
+export function isRequestInlineContentDisposition(filetype: string): boolean {
+  return [...HTML_FILETYPE_LIST, ...IMAGE_FILETYPE_LIST].includes(filetype);
+}

--- a/src/containers/subjects/AnalysisResultTable/index.tsx
+++ b/src/containers/subjects/AnalysisResultTable/index.tsx
@@ -14,6 +14,7 @@ import { Button } from 'primereact/button';
 import { BlockUI } from 'primereact/blockui';
 import { DATA_TYPE_SUPPORTED } from '../../../components/ViewPresignedUrl';
 import { Toast } from 'primereact/toast';
+import mime from 'mime';
 
 // Creating Table
 type AnalysisResultGDSTableProps = {
@@ -33,7 +34,10 @@ const filenameTemplate = (rowData: Record<string, any>) => {
     if (rowData.path) {
       try {
         const signed_url = await getGDSPreSignedUrl(rowData.id, {
-          headers: { 'Content-Disposition': 'inline' },
+          headers: {
+            'Content-Disposition': 'inline',
+            'Content-Type': mime.getType(rowData.path),
+          },
         });
         window.open(signed_url, '_blank');
       } catch (e) {
@@ -191,16 +195,14 @@ const downloadGDSTemplate = (rowData: GDSRow) => {
   const filename = rowData.path.split('/').pop() ?? rowData.path;
   // const fileSizeInBytes = rowData.size_in_bytes;
   const filetype = filename.split('.').pop();
-  const allowFileTypes = [...DATA_TYPE_SUPPORTED];
+  const allowFileTypes = ['gz', 'maf', ...DATA_TYPE_SUPPORTED];
   const allowDownload = allowFileTypes.includes(filetype as string);
 
   const handleDownload = async (rowData: GDSRow) => {
     setBlockedPanel(true);
     if (rowData.path) {
       try {
-        const signed_url = await getGDSPreSignedUrl(rowData.id, {
-          headers: { 'Content-Disposition': 'attachment' },
-        });
+        const signed_url = await getGDSPreSignedUrl(rowData.id);
         window.open(signed_url, '_blank');
       } catch (e) {
         setBlockedPanel(false);

--- a/src/containers/subjects/AnalysisResultTable/index.tsx
+++ b/src/containers/subjects/AnalysisResultTable/index.tsx
@@ -12,7 +12,10 @@ import { getS3PreSignedUrl, S3Row } from '../../../api/s3';
 import { GDSRow, getGDSPreSignedUrl } from '../../../api/gds';
 import { Button } from 'primereact/button';
 import { BlockUI } from 'primereact/blockui';
-import { DATA_TYPE_SUPPORTED } from '../../../components/ViewPresignedUrl';
+import {
+  DATA_TYPE_SUPPORTED,
+  isRequestInlineContentDisposition,
+} from '../../../components/ViewPresignedUrl';
 import { Toast } from 'primereact/toast';
 import mime from 'mime';
 
@@ -28,6 +31,8 @@ const filenameTemplate = (rowData: Record<string, any>) => {
   let filename;
   if (rowData.path) filename = rowData.path.split('/').pop();
   if (rowData.key) filename = rowData.key.split('/').pop();
+  const split_path = filename.split('.');
+  const filetype = split_path[split_path.length - 1].toLowerCase();
 
   const handleOpenInBrowser = async (rowData: Record<string, any>) => {
     setBlockedPanel(true);
@@ -35,7 +40,9 @@ const filenameTemplate = (rowData: Record<string, any>) => {
       try {
         const signed_url = await getGDSPreSignedUrl(rowData.id, {
           headers: {
-            'Content-Disposition': 'inline',
+            'Content-Disposition': isRequestInlineContentDisposition(filetype)
+              ? 'inline'
+              : 'attachment',
             'Content-Type': mime.getType(rowData.path),
           },
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1750,6 +1750,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
+"@types/mime@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
+  integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
+
 "@types/node@^18.15.10":
   version "18.15.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.10.tgz#4ee2171c3306a185d1208dad5f44dae3dee4cfe3"
@@ -3081,6 +3086,11 @@ microseconds@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
   integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
+
+mime@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-3.0.0.tgz#b374550dca3a0c18443b0c950a6a58f1931cf7a7"
+  integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
 
 minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"


### PR DESCRIPTION
* Improved PreSigned API call implementation by clear separation between
  * By default, without API Config override, use attachment download mode
  * Any inline rendering need, must API call with providing headers --
    Content-Disposition
    Content-Type
  * See https://github.com/umccr/data-portal-apis/pull/585
  * Related #257

* Added mime package for determining content type
* Added Analysis Results download icon support for gz, maf formats
