### PR TITLE
Remove `srcDoc` from `<iframe/>`

### DIFF
--- a/src/components/ViewPresignedUrl/index.tsx
+++ b/src/components/ViewPresignedUrl/index.tsx
@@ -67,18 +67,7 @@ export default function ViewPresignedUrl({ presingedUrl }: Props) {
   }
 
   // Return HTML (via iframe) display
-
-  /** **************************** TEMPORARY SOLUTION ****************************
-   *
-   * Only allow S3 presigned url that is allowed to be viewed in this <iframe/> tag.
-   *
-   * See below 'TEMPORARY SOLUTION' block for details. Change to original solution if the fix has been made.
-   *
-   * Current solution: if (HTML_FILETYPE_LIST.includes(filetype) && presingedUrl.startsWith('https://umccr')) {
-   * Original solution: if (HTML_FILETYPE_LIST.includes(filetype)) {
-   *
-   * */
-  if (HTML_FILETYPE_LIST.includes(filetype) && presingedUrl.startsWith('https://umccr')) {
+  if (HTML_FILETYPE_LIST.includes(filetype)) {
     return (
       <div className='w-full h-full'>
         <iframe className='w-full h-full bg-white' src={presingedUrl} />
@@ -108,26 +97,6 @@ export default function ViewPresignedUrl({ presingedUrl }: Props) {
   if (isLoading || isFetching || !data) {
     return <CircularLoaderWithText text='Fetching Content' />;
   }
-
-  /** **************************** TEMPORARY SOLUTION ****************************
-   *
-   * This is specific to GDS data as `Content-Type` might be incorrect on GDS presigned URL. This causes
-   * iframe to download file instead of showing it. This is just a work around to download the content
-   * and show with srcDoc in iframe.
-   *
-   * This is a temporary solution. Remove this block when permanent solution is in place.
-   *
-   * Ref: https://umccr.slack.com/archives/CP356DDCH/p1677563982961669?thread_ts=1677476635.509959&cid=CP356DDCH
-   *  */
-
-  if (HTML_FILETYPE_LIST.includes(filetype) && presingedUrl.startsWith('https://stratus-gds')) {
-    return (
-      <div className='w-full h-full'>
-        <iframe className='w-full h-full bg-white' srcDoc={data} />
-      </div>
-    );
-  }
-  /** ************************* END TEMPORARY SOLUTION BLOCK ********************** */
 
   // Return JSON
   if (filetype == 'json') {


### PR DESCRIPTION
It turns out using `srcDoc` from `<iframe/>` need somehow isolation (based from quick googling), as with current implementation clicking a link from the html previewer will redirect to the parent link. Reproducible by clicking a link from the HTML previewer (say from a `multiqc.html`) in `stg` or `prod`.

Since https://github.com/umccr/data-portal-apis/pull/581 has been done, will reimplement this to the original solution.