### PR TITLE
hotfix for cttsov2 portalRunId

### DIFF
--- a/src/containers/subjects/AnalysisResultTable/index.tsx
+++ b/src/containers/subjects/AnalysisResultTable/index.tsx
@@ -109,13 +109,20 @@ const filenameTemplate = (rowData: Record<string, any>) => {
  */
 
 const portalRunIdTemplate = (rowData: Record<string, any>) => {
-  const portalRunId = rowData.key ? rowData.key.split('/')[3] : rowData.path.split('/')[4];
+  const portalRunId = rowData.key ? getPortalRunIdFromS3Key(rowData.key) : rowData.path.split('/')[4];
   return (
     <div className='white-space-nowrap overflow-visible' style={{ width: '130x' }}>
       {portalRunId}
     </div>
   );
 };
+
+// Fix: cttsov2 have one more layer than other data in the s3 key
+const getPortalRunIdFromS3Key = (key: string) => {
+  const tmp = key.split('/')[3]
+  // if tmp not shtart with 8 digits, then it is the extra layer
+  return /^\d{8}/.test(tmp) ? tmp : key.split('/')[4];
+}
 
 const actionGDSTemplate = (rowData: GDSRow) => {
   return (


### PR DESCRIPTION
Fix for #327  PortalRunId column display issue.


#### Reason
cttsov2 key has one more layer in key attribute
```
key: "byob-icav2/development/analysis/cttsov2/202406214ff0a712/Logs_Intermediates/DragenCaller/L2400165/L2400165_tumor.bam"
```
noraml sash object key:
```
key:"analysis_data/SBJ04375/sash/2023102824ce1c40/L2301202_L2301201/SBJ04375_MDX230471/smlv_somatic/filter/MDX230471.annotations.pass.vcf.gz
```

#### Fix
Add one `check function: getPortalRunIdFromS3Key` when retrieve portalRunId from s3 key. If the 4th layer didn't start with 8 digits, we will try next layer. 
It just have these two situation so far, either in 4th layer or 5th.