### PR TITLE
Fix SideBar Menu Click Reload 

### DIFF
--- a/src/containers/subjects/SubjectSideBar/index.tsx
+++ b/src/containers/subjects/SubjectSideBar/index.tsx
@@ -24,7 +24,7 @@ function SubjectSideBar() {
   const itemTemplate = (option: { postfixPath: string; label: string }) => {
     return (
       // Will wrap in an '<a>' tag (with href) to get the benefit open in new tab/window from right-click
-      <a href={option.postfixPath} style={{ all: 'unset' }}>
+      <a onClick={(e) => e.preventDefault()} href={option.postfixPath} style={{ all: 'unset' }}>
         <div>{option.label}</div>
       </a>
     );


### PR DESCRIPTION
Resolve #341 

Adding preventDefault fixes it, perhaps they change how onClick ordering/priority in the `ListBox` component